### PR TITLE
Get some of the metadata methods working

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -108,8 +108,8 @@ func (im *InstanceMetadata) GetFloat32(key string) (f float32, err error) {
 			err = fmt.Errorf("failed to cast interface to float32")
 		}
 	}()
-	v, err := im.getItem(key)
-	return v.(float32), err
+	v, err := im.GetFloat64(key)
+	return float32(v), err
 }
 
 // GetFloat64 pulls a value cast as float. Swallows panics from type assertion

--- a/tests/metadata_test.go
+++ b/tests/metadata_test.go
@@ -51,3 +51,33 @@ func TestGetInt(t *testing.T) {
 		})
 	})
 }
+
+func TestGetFloat(t *testing.T) {
+	Convey("Given an instance", t, func() {
+		instance := new(fargo.Instance)
+		Convey("With metadata", func() {
+			metadata := new(fargo.InstanceMetadata)
+			instance.Metadata = *metadata
+			Convey("That has a float value", func() {
+				key := "d"
+				value := 1.9
+				metadata.Raw = []byte("<" + key + ">" + strconv.FormatFloat(value, 'f', -1, 64) + "</" + key + ">")
+				Convey("GetFloat64 should return that value", func() {
+					actualValue, err := metadata.GetFloat64(key)
+					So(err, ShouldBeNil)
+					So(actualValue, ShouldEqual, value)
+				})
+			})
+			Convey("That has a float value", func() {
+				key := "d"
+				value := 1.9
+				metadata.Raw = []byte("<" + key + ">" + strconv.FormatFloat(value, 'f', -1, 32) + "</" + key + ">")
+				Convey("GetFloat32 should return that value", func() {
+					actualValue, err := metadata.GetFloat32(key)
+					So(err, ShouldBeNil)
+					So(actualValue, ShouldEqual, float32(1.9))
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
The x2j package only supports string, float64, and bool types, so `GetInt` didn't work. 

`GetFloat32` probably still does not work.
