### PR TITLE
Prevent Fargo from stomping all over log settings

### DIFF
--- a/log.go
+++ b/log.go
@@ -4,15 +4,7 @@ package fargo
 
 import (
 	"github.com/op/go-logging"
-	stdlog "log"
-	"os"
 )
 
 var log = logging.MustGetLogger("fargo")
 
-func init() {
-	logBackend := logging.NewLogBackend(os.Stderr, "[fargo] ", stdlog.LstdFlags|stdlog.Lshortfile)
-	logBackend.Color = true
-	logging.SetBackend(logBackend)
-	logging.SetLevel(logging.INFO, "")
-}


### PR DESCRIPTION
The logging library we use only lets us set one log backend, and sadly, Fargo's default settings stomp over mine as soon as I load it meaning I can't get debug logs.

This PR removes the init function from log.go and leaves it up to the entry point of an application to initialize the log. 

If [go-logging](https://github.com/op/go-logging) adds a way to discover if a backend is already set, we could add this block back in with a check for an existing backend.
