### PR TITLE
Fix open socket leak

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -87,6 +87,8 @@ func netReq(req *http.Request) ([]byte, int, error) {
 			log.Warning("Retrying after temporary network failure, error: %s",
 				nerr.Error())
 			time.Sleep(10)
+		} else {
+			break
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
Good news:
This commit appears to fix the resource leak that breaks long-running
apps.

Bad news:
We have to be extra careful to make sure all http requests are cleaned
up properly, or apps will silently stop working (not crash). 

As part of cleaning up resources, response bodies must be [read from
before being closed](https://stackoverflow.com/questions/17948827/reusing-http-connections-in-golang).
