### PR TITLE
fix dns_discovery init() call breaks in windows

### DIFF
--- a/dns_discover.go
+++ b/dns_discover.go
@@ -78,10 +78,10 @@ func findDnsServerAddr() (string, error) {
 	// Find a DNS server using the OS resolv.conf
 	config, err := dns.ClientConfigFromFile("/etc/resolv.conf")
 	if err != nil {
-		return config.Servers[0] + ":" + config.Port, nil
-	} else {
 		log.Error("Failure finding DNS server address from /etc/resolv.conf, err = %s", err)
 		return "", err
+	} else {
+		return config.Servers[0] + ":" + config.Port, nil
 	}
 }
 


### PR DESCRIPTION
https://github.com/hudl/fargo/blob/master/dns_discover.go#L75

This line gets executed when the fargo package are imported, and on a windows system, this file doesn't exist, and therefore breaks the application even if the application does not really use the dns discovery feature.

So I basically change the init() call to a normal function and propagate the error so it doesn't break on windows when the feature is not enabled.
