### PR TITLE
Add backoff/retry for DNS queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ for {
 # TODO
 
 * Actually do something with AWS availability zone info
-* Allow service url distribution via DNS
 * Currently the load balancing is random, and does not give preference to
   servers within a zone.
 * Make releases available on [gopkg.in](http://gopkg.in)

--- a/dns_discover.go
+++ b/dns_discover.go
@@ -41,7 +41,7 @@ func discoverDNS(domain string, port int) (servers []string, ttl time.Duration, 
 	return
 }
 
-// retryingFindTXT will, on any DNS failure, retry for up to 10 minutes before
+// retryingFindTXT will, on any DNS failure, retry for up to 15 minutes before
 // giving up and returning an empty []string of records
 func retryingFindTXT(fqdn string) (records []string, ttl time.Duration, err error) {
 	err = backoff.Retry(

--- a/dns_discover_test.go
+++ b/dns_discover_test.go
@@ -49,7 +49,7 @@ func TestGetNetflixTestDomain(t *testing.T) {
 		servers, ttl, err := discoverDNS("discoverytest.netflix.net", 7001)
 		So(ttl, ShouldEqual, 60*time.Second)
 		So(err, ShouldBeNil)
-		So(len(servers), ShouldEqual, 4)
+		So(len(servers), ShouldEqual, 6)
 		Convey("Servers discovered should all be EC2 DNS names", func() {
 			for _, s := range servers {
 				So(s[0:11], ShouldEqual, "http://ec2-")


### PR DESCRIPTION
The `retryingFindTXT` method will mask temporary failures (under 15
minutes) by retrying any DNS queries that fail.

Addresses #15 