### PR TITLE
don't strip zone letter from availability zone

### DIFF
--- a/dns_discover.go
+++ b/dns_discover.go
@@ -126,5 +126,5 @@ func availabilityZone() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return zone[:len(zone)-1], nil
+	return zone, nil
 }


### PR DESCRIPTION
The availabilityZone () function strips off the letter that indicates the availability zone. When combined with the fact that the region() does the same thing, the region returns a string with the region number stripped off (eg. you get "us-west-"). This fix just changes the availabilityZone() method to not strip the final letter.