### PR TITLE
avoid chance of division by 0 panic

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -35,6 +35,9 @@ func (e *EurekaConnection) SelectServiceURL() string {
 }
 
 func choice(options []string) string {
+	if len(options) == 0 {
+		return ""
+	}
 	return options[rand.Int()%len(options)]
 }
 


### PR DESCRIPTION
Avoid the possibility of a division by 0 error by checking length and returning empty value when length is 0. Allows calling code to manage situation without adding complications.