### PR TITLE
Add missing *Url fields to Instance struct

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -89,6 +89,10 @@ type Instance struct {
 	SecurePort  int  `xml:"securePort" json:"-"`
 	SecurePortJ Port `json:"securePort" xml:"-"`
 
+	HomePageUrl    string `xml:"homePageUrl" json:"homePageUrl"`
+	StatusPageUrl  string `xml:"statusPageUrl" json:"statusPageUrl"`
+	HealthCheckUrl string `xml:"healthCheckUrl" json:"healthCheckUrl"`
+
 	CountryId      int64          `xml:"countryId" json:"countryId"`
 	DataCenterInfo DataCenterInfo `xml:"dataCenterInfo" json:"dataCenterInfo"`
 


### PR DESCRIPTION
I asked on the Eureka mailing list about the missing *URL fields in the REST documentation and they updated them (the XSD doc at the end). This PR adds them to the Instance struct.