### PR TITLE
Allow for customizable instance IDs ... and a few fixes

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -113,5 +113,10 @@ func (i *InstanceMetadata) MarshalJSON() ([]byte, error) {
 	if i.parsed != nil {
 		return json.Marshal(i.parsed)
 	}
+
+	if i.Raw == nil {
+		i.Raw = []byte("{}")
+	}
+
 	return i.Raw, nil
 }

--- a/net.go
+++ b/net.go
@@ -291,9 +291,13 @@ func (e *EurekaConnection) HeartBeatInstance(ins *Instance) error {
 }
 
 func (i *Instance) Id() string {
+	if i.UniqueID != nil {
+		return i.UniqueID(*i)
+	}
+
 	if i.DataCenterInfo.Name == "Amazon" {
 		return i.DataCenterInfo.Metadata.InstanceID
 	}
-	return i.HostName
 
+	return i.HostName
 }

--- a/net.go
+++ b/net.go
@@ -199,6 +199,7 @@ func (e *EurekaConnection) GetInstance(app, insId string) (*Instance, error) {
 func (e *EurekaConnection) readInstanceInto(ins *Instance) error {
 	tins, err := e.GetInstance(ins.App, ins.Id())
 	if err == nil {
+		tins.UniqueID = ins.UniqueID
 		*ins = *tins
 	}
 	return err

--- a/provision_eureka.sh
+++ b/provision_eureka.sh
@@ -19,7 +19,9 @@ echo "127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdom
 172.16.0.22 node2 node2.localdomain
 " > /etc/hosts
 
-wget -O /var/lib/tomcat/webapps/eureka.zip https://netflixoss.ci.cloudbees.com/job/eureka-master/lastSuccessfulBuild/artifact/eureka-server/build/libs/eureka-server-1.1.135-SNAPSHOT.war
+ARTIFACT="https://netflixoss.ci.cloudbees.com/job/eureka-master/lastSuccessfulBuild/artifact/eureka-server/build/libs/eureka-server-1.1.147-SNAPSHOT.war"
+
+wget -O /var/lib/tomcat/webapps/eureka.zip ${ARTIFACT}
 unzip -o -d /var/lib/tomcat/webapps/eureka /var/lib/tomcat/webapps/eureka.zip
 cp /vagrant/tests/eureka_properties/*.properties /var/lib/tomcat/webapps/eureka/WEB-INF/classes/
 chown -R tomcat:tomcat /var/lib/tomcat/webapps/eureka

--- a/struct.go
+++ b/struct.go
@@ -98,6 +98,8 @@ type Instance struct {
 
 	LeaseInfo LeaseInfo        `xml:"leaseInfo" json:"leaseInfo"`
 	Metadata  InstanceMetadata `xml:"metadata" json:"metadata"`
+
+	UniqueID func(i Instance) string `xml:"-" json:"-"`
 }
 
 // Port struct used for JSON [un]marshaling only

--- a/tests/instance_test.go
+++ b/tests/instance_test.go
@@ -1,0 +1,95 @@
+package fargo_test
+
+// MIT Licensed (see README.md)
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hudl/fargo"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestInstanceID(t *testing.T) {
+	i := fargo.Instance{
+		HostName:         "i-6543",
+		Port:             9090,
+		App:              "TESTAPP",
+		IPAddr:           "127.0.0.10",
+		VipAddress:       "127.0.0.10",
+		SecureVipAddress: "127.0.0.10",
+		Status:           fargo.UP,
+	}
+
+	Convey("Given an instance with DataCenterInfo.Name set to Amazon", t, func() {
+		i.DataCenterInfo = fargo.DataCenterInfo{Name: fargo.Amazon}
+
+		Convey("When UniqueID function has NOT been set", func() {
+			i.UniqueID = nil
+
+			Convey("And InstanceID has been set in AmazonMetadata", func() {
+				i.DataCenterInfo.Metadata.InstanceID = "EXPECTED-ID"
+
+				Convey("Id() should return the provided InstanceID", func() {
+					So(i.Id(), ShouldEqual, "EXPECTED-ID")
+				})
+			})
+
+			Convey("And InstanceID has NOT been set in AmazonMetadata", func() {
+				i.DataCenterInfo.Metadata.InstanceID = ""
+
+				Convey("Id() should return an empty string", func() {
+					So(i.Id(), ShouldEqual, "")
+				})
+			})
+		})
+
+		Convey("When UniqueID function has been set", func() {
+			i.UniqueID = func(i fargo.Instance) string {
+				return fmt.Sprintf("%s:%d", i.App, 123)
+			}
+
+			Convey("And InstanceID has been set in AmazonMetadata", func() {
+				i.DataCenterInfo.Metadata.InstanceID = "UNEXPECTED"
+
+				Convey("Id() should return the ID that is provided by UniqueID", func() {
+					So(i.Id(), ShouldEqual, "TESTAPP:123")
+				})
+			})
+
+			Convey("And InstanceID has not been set in AmazonMetadata", func() {
+				i.DataCenterInfo.Metadata.InstanceID = ""
+
+				Convey("Id() should return the ID that is provided by UniqueID", func() {
+					So(i.Id(), ShouldEqual, "TESTAPP:123")
+				})
+			})
+		})
+	})
+
+	Convey("Given an instance with DataCenterInfo.Name set to MyOwn", t, func() {
+		i.DataCenterInfo = fargo.DataCenterInfo{Name: fargo.MyOwn}
+
+		Convey("When UniqueID function has NOT been set", func() {
+			i.UniqueID = nil
+
+			Convey("Id() should return the host name", func() {
+				So(i.Id(), ShouldEqual, "i-6543")
+			})
+		})
+
+		Convey("When UniqueID function has been set", func() {
+			i.Metadata.Raw = []byte(`{"instanceId": "unique-id"}`)
+			i.UniqueID = func(i fargo.Instance) string {
+				if id, err := i.Metadata.GetString("instanceId"); err == nil {
+					return fmt.Sprintf("%s:%s", i.HostName, id)
+				}
+				return i.HostName
+			}
+
+			Convey("Id() should return the ID that is provided by UniqueID", func() {
+				So(i.Id(), ShouldEqual, "i-6543:unique-id")
+			})
+		})
+	})
+}

--- a/tests/metadata_test.go
+++ b/tests/metadata_test.go
@@ -35,7 +35,7 @@ func TestGetFloat(t *testing.T) {
 		Convey("With metadata", func() {
 			metadata := new(fargo.InstanceMetadata)
 			instance.Metadata = *metadata
-			Convey("That has a float value", func() {
+			Convey("That has a float64 value", func() {
 				key := "d"
 				value := 1.9
 				metadata.Raw = []byte("<" + key + ">" + strconv.FormatFloat(value, 'f', -1, 64) + "</" + key + ">")
@@ -45,7 +45,7 @@ func TestGetFloat(t *testing.T) {
 					So(actualValue, ShouldEqual, value)
 				})
 			})
-			Convey("That has a float value", func() {
+			Convey("That has a float32 value", func() {
 				key := "d"
 				value := 1.9
 				metadata.Raw = []byte("<" + key + ">" + strconv.FormatFloat(value, 'f', -1, 32) + "</" + key + ">")

--- a/tests/net_test.go
+++ b/tests/net_test.go
@@ -86,33 +86,39 @@ func TestRegistration(t *testing.T) {
 
 func TestReregistration(t *testing.T) {
 	e, _ := fargo.NewConnFromConfigFile("./config_sample/local.gcfg")
-	i := fargo.Instance{
-		HostName:         "i-123456",
-		Port:             9090,
-		App:              "TESTAPP",
-		IPAddr:           "127.0.0.10",
-		VipAddress:       "127.0.0.10",
-		DataCenterInfo:   fargo.DataCenterInfo{Name: fargo.MyOwn},
-		SecureVipAddress: "127.0.0.10",
-		Status:           fargo.UP,
-	}
+
 	for _, j := range []bool{false, true} {
 		e.UseJson = j
+
+		i := fargo.Instance{
+			HostName:         "i-123456",
+			Port:             9090,
+			App:              "TESTAPP",
+			IPAddr:           "127.0.0.10",
+			VipAddress:       "127.0.0.10",
+			DataCenterInfo:   fargo.DataCenterInfo{Name: fargo.MyOwn},
+			SecureVipAddress: "127.0.0.10",
+			Status:           fargo.UP,
+		}
+
 		Convey("Register a TESTAPP instance", t, func() {
 			Convey("Instance registers correctly", func() {
 				err := e.RegisterInstance(&i)
 				So(err, ShouldBeNil)
 			})
 		})
+
 		Convey("Reregister the TESTAPP instance", t, func() {
 			Convey("Instance reregisters correctly", func() {
 				err := e.ReregisterInstance(&i)
 				So(err, ShouldBeNil)
 			})
+
 			Convey("Instance can check in", func() {
 				err := e.HeartBeatInstance(&i)
 				So(err, ShouldBeNil)
 			})
+
 			Convey("Instance can be gotten correctly", func() {
 				ii, err := e.GetInstance(i.App, i.HostName)
 				So(err, ShouldBeNil)


### PR DESCRIPTION
The main purpose of this PR is to add the ability to use custom instance IDs. This is needed in order to register multiple instances of the same app in a PAAS like Cloud Foundry. In such an environment the host name is the same for multiple instances of an app. Thus, using the host name as the instance ID will cause collisions in the registry. Beside the PAAS-case there are other use cases that require this feature, e.g. docker containers running on the same host.

This functionality has been added to the Java client a while ago, for details see https://github.com/Netflix/eureka/pull/85.

The rest of the commits in this PR were needed to (a) get the Vagrant boxes up and running and (b) have all tests pass.

Let me know if you've got any questions. Thanks!