### PR TITLE
Change loggin function to have f postfix when using formated version

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,7 +46,7 @@ type eureka struct {
 func ReadConfig(loc string) (conf Config, err error) {
 	err = gcfg.ReadFileInto(&conf, loc)
 	if err != nil {
-		log.Critical("Unable to read config file Error: %s", err.Error())
+		log.Criticalf("Unable to read config file Error: %s", err.Error())
 		return conf, err
 	}
 	conf.fillDefaults()

--- a/connection.go
+++ b/connection.go
@@ -46,7 +46,7 @@ func choice(options []string) string {
 func NewConnFromConfigFile(location string) (c EurekaConnection, err error) {
 	cfg, err := ReadConfig(location)
 	if err != nil {
-		log.Error("Problem reading config %s error: %s", location, err.Error())
+		log.Errorf("Problem reading config %s error: %s", location, err.Error())
 		return c, err
 	}
 	return NewConnFromConfig(cfg), nil
@@ -84,10 +84,10 @@ func NewConn(address ...string) (e EurekaConnection) {
 func (e *EurekaConnection) UpdateApp(app *Application) {
 	go func() {
 		for {
-			log.Notice("Updating app %s", app.Name)
+			log.Noticef("Updating app %s", app.Name)
 			err := e.readAppInto(app)
 			if err != nil {
-				log.Error("Failure updating %s in goroutine", app.Name)
+				log.Errorf("Failure updating %s in goroutine", app.Name)
 			}
 			<-time.After(time.Duration(e.PollInterval) * time.Second)
 		}

--- a/dns_discover.go
+++ b/dns_discover.go
@@ -48,7 +48,7 @@ func retryingFindTXT(fqdn string) (records []string, ttl time.Duration, err erro
 		func() error {
 			records, ttl, err = findTXT(fqdn)
 			if err != nil {
-				log.Error("Retrying DNS query. Query failed with: %s", err.Error())
+				log.Errorf("Retrying DNS query. Query failed with: %s", err.Error())
 			}
 			return err
 		}, backoff.NewExponentialBackOff())
@@ -61,23 +61,23 @@ func findTXT(fqdn string) ([]string, time.Duration, error) {
 	query.SetQuestion(fqdn, dns.TypeTXT)
 	dnsServerAddr, err := findDnsServerAddr()
 	if err != nil {
-		log.Error("Failure finding DNS server, err=%s", err.Error())
+		log.Errorf("Failure finding DNS server, err=%s", err.Error())
 		return nil, defaultTTL, err
 	}
 
 	response, err := dns.Exchange(query, dnsServerAddr)
 	if err != nil {
-		log.Error("Failure resolving name %s err=%s", fqdn, err.Error())
+		log.Errorf("Failure resolving name %s err=%s", fqdn, err.Error())
 		return nil, defaultTTL, err
 	}
 	if len(response.Answer) < 1 {
 		err := fmt.Errorf("no Eureka discovery TXT record returned for name=%s", fqdn)
-		log.Error("no answer for name=%s err=%s", fqdn, err.Error())
+		log.Errorf("no answer for name=%s err=%s", fqdn, err.Error())
 		return nil, defaultTTL, err
 	}
 	if response.Answer[0].Header().Rrtype != dns.TypeTXT {
 		err := fmt.Errorf("did not receive TXT record back from query specifying TXT record. This should never happen.")
-		log.Error("Failure resolving name %s err=%s", fqdn, err.Error())
+		log.Errorf("Failure resolving name %s err=%s", fqdn, err.Error())
 		return nil, defaultTTL, err
 	}
 	txt := response.Answer[0].(*dns.TXT)
@@ -93,7 +93,7 @@ func findDnsServerAddr() (string, error) {
 	// Find a DNS server using the OS resolv.conf
 	config, err := dns.ClientConfigFromFile("/etc/resolv.conf")
 	if err != nil {
-		log.Error("Failure finding DNS server address from /etc/resolv.conf, err = %s", err)
+		log.Errorf("Failure finding DNS server address from /etc/resolv.conf, err = %s", err)
 		return "", err
 	} else {
 		return config.Servers[0] + ":" + config.Port, nil
@@ -103,7 +103,7 @@ func findDnsServerAddr() (string, error) {
 func region() (string, error) {
 	zone, err := availabilityZone()
 	if err != nil {
-		log.Error("Could not retrieve availability zone err=%s", err.Error())
+		log.Errorf("Could not retrieve availability zone err=%s", err.Error())
 		return "us-east-1", err
 	}
 	return zone[:len(zone)-1], nil

--- a/marshal.go
+++ b/marshal.go
@@ -19,7 +19,7 @@ type getAppsResponseSingle struct {
 // UnmarshalJSON is a custom JSON unmarshaler for GetAppsResponse to deal with
 // sometimes non-wrapped Application arrays when there is only a single Application item.
 func (r *GetAppsResponse) UnmarshalJSON(b []byte) error {
-	marshalLog.Debug("GetAppsResponse.UnmarshalJSON b:%s\n", string(b))
+	marshalLog.Debugf("GetAppsResponse.UnmarshalJSON b:%s\n", string(b))
 	var err error
 
 	// Normal array case
@@ -52,7 +52,7 @@ type applicationSingle struct {
 // UnmarshalJSON is a custom JSON unmarshaler for Application to deal with
 // sometimes non-wrapped Instance array when there is only a single Instance item.
 func (a *Application) UnmarshalJSON(b []byte) error {
-	marshalLog.Debug("Application.UnmarshalJSON b:%s\n", string(b))
+	marshalLog.Debugf("Application.UnmarshalJSON b:%s\n", string(b))
 	var err error
 
 	// Normal array case
@@ -96,7 +96,7 @@ func (i *Instance) UnmarshalJSON(b []byte) error {
 func parsePort(s string) int {
 	n, err := strconv.Atoi(s)
 	if err != nil {
-		log.Warning("Invalid port error: %s", err.Error())
+		log.Warningf("Invalid port error: %s", err.Error())
 	}
 	return n
 }

--- a/metadata.go
+++ b/metadata.go
@@ -13,7 +13,7 @@ func (a *Application) ParseAllMetadata() error {
 	for _, instance := range a.Instances {
 		err := instance.Metadata.parse()
 		if err != nil {
-			log.Error("Failed parsing metadata for Instance=%s of Application=%s: %s",
+			log.Errorf("Failed parsing metadata for Instance=%s of Application=%s: %s",
 				instance.HostName, a.Name, err.Error())
 			return err
 		}
@@ -35,13 +35,13 @@ func (im *InstanceMetadata) parse() error {
 		log.Debug("len(Metadata)==0. Quitting parsing.")
 		return nil
 	}
-	metadataLog.Debug("InstanceMetadata.parse: %s", im.Raw)
+	metadataLog.Debugf("InstanceMetadata.parse: %s", im.Raw)
 
 	if len(im.Raw) > 0 && im.Raw[0] == '{' {
 		// JSON
 		err := json.Unmarshal(im.Raw, &im.parsed)
 		if err != nil {
-			log.Error("Error unmarshalling: %s", err.Error())
+			log.Errorf("Error unmarshalling: %s", err.Error())
 			return fmt.Errorf("error unmarshalling: %s", err.Error())
 		}
 	} else {
@@ -49,7 +49,7 @@ func (im *InstanceMetadata) parse() error {
 		fullDoc := append(append([]byte("<d>"), im.Raw...), []byte("</d>")...)
 		parsedDoc, err := x2j.ByteDocToMap(fullDoc, true)
 		if err != nil {
-			log.Error("Error unmarshalling: %s", err.Error())
+			log.Errorf("Error unmarshalling: %s", err.Error())
 			return fmt.Errorf("error unmarshalling: %s", err.Error())
 		}
 		im.parsed = parsedDoc["d"].(map[string]interface{})

--- a/net.go
+++ b/net.go
@@ -21,7 +21,7 @@ func (e *EurekaConnection) marshal(v interface{}) ([]byte, error) {
 		if err != nil {
 			// marshal the JSON *with* indents so it's readable in the error message
 			out, _ := json.MarshalIndent(v, "", "    ")
-			log.Error("Error marshalling JSON value=%v. Error:\"%s\" JSON body=\"%s\"", v, err.Error(), string(out))
+			log.Errorf("Error marshalling JSON value=%v. Error:\"%s\" JSON body=\"%s\"", v, err.Error(), string(out))
 			return nil, err
 		}
 		return out, nil
@@ -30,7 +30,7 @@ func (e *EurekaConnection) marshal(v interface{}) ([]byte, error) {
 		if err != nil {
 			// marshal the XML *with* indents so it's readable in the error message
 			out, _ := xml.MarshalIndent(v, "", "    ")
-			log.Error("Error marshalling XML value=%v. Error:\"%s\" JSON body=\"%s\"", v, err.Error(), string(out))
+			log.Errorf("Error marshalling XML value=%v. Error:\"%s\" JSON body=\"%s\"", v, err.Error(), string(out))
 			return nil, err
 		}
 		return out, nil
@@ -41,18 +41,18 @@ func (e *EurekaConnection) marshal(v interface{}) ([]byte, error) {
 func (e *EurekaConnection) GetApp(name string) (*Application, error) {
 	slug := fmt.Sprintf("%s/%s", EurekaURLSlugs["Apps"], name)
 	reqURL := e.generateURL(slug)
-	log.Debug("Getting app %s from url %s", name, reqURL)
+	log.Debugf("Getting app %s from url %s", name, reqURL)
 	out, rcode, err := getBody(reqURL, e.UseJson)
 	if err != nil {
-		log.Error("Couldn't get app %s, error: %s", name, err.Error())
+		log.Errorf("Couldn't get app %s, error: %s", name, err.Error())
 		return nil, err
 	}
 	if rcode == 404 {
-		log.Error("App %s not found (received 404)", name)
+		log.Errorf("App %s not found (received 404)", name)
 		return nil, AppNotFoundError{specific: name}
 	}
 	if rcode > 299 || rcode < 200 {
-		log.Warning("Non-200 rcode of %d", rcode)
+		log.Warningf("Non-200 rcode of %d", rcode)
 	}
 
 	var v *Application
@@ -64,7 +64,7 @@ func (e *EurekaConnection) GetApp(name string) (*Application, error) {
 		err = xml.Unmarshal(out, &v)
 	}
 	if err != nil {
-		log.Error("Unmarshalling error: %s", err.Error())
+		log.Errorf("Unmarshalling error: %s", err.Error())
 		return nil, err
 	}
 
@@ -84,14 +84,14 @@ func (e *EurekaConnection) readAppInto(app *Application) error {
 func (e *EurekaConnection) GetApps() (map[string]*Application, error) {
 	slug := EurekaURLSlugs["Apps"]
 	reqURL := e.generateURL(slug)
-	log.Debug("Getting all apps from url %s", reqURL)
+	log.Debugf("Getting all apps from url %s", reqURL)
 	body, rcode, err := getBody(reqURL, e.UseJson)
 	if err != nil {
-		log.Error("Couldn't get apps, error: %s", err.Error())
+		log.Errorf("Couldn't get apps, error: %s", err.Error())
 		return nil, err
 	}
 	if rcode > 299 || rcode < 200 {
-		log.Warning("Non-200 rcode of %d", rcode)
+		log.Warningf("Non-200 rcode of %d", rcode)
 	}
 
 	var r *GetAppsResponse
@@ -103,7 +103,7 @@ func (e *EurekaConnection) GetApps() (map[string]*Application, error) {
 		err = xml.Unmarshal(body, &r)
 	}
 	if err != nil {
-		log.Error("Unmarshalling error: %s", err.Error())
+		log.Errorf("Unmarshalling error: %s", err.Error())
 		return nil, err
 	}
 
@@ -112,7 +112,7 @@ func (e *EurekaConnection) GetApps() (map[string]*Application, error) {
 		apps[a.Name] = r.Applications[i]
 	}
 	for name, app := range apps {
-		log.Debug("Parsing metadata for app %s", name)
+		log.Debugf("Parsing metadata for app %s", name)
 		app.ParseAllMetadata()
 	}
 	return apps, nil
@@ -124,18 +124,18 @@ func (e *EurekaConnection) GetApps() (map[string]*Application, error) {
 func (e *EurekaConnection) RegisterInstance(ins *Instance) error {
 	slug := fmt.Sprintf("%s/%s", EurekaURLSlugs["Apps"], ins.App)
 	reqURL := e.generateURL(slug)
-	log.Debug("Registering instance with url %s", reqURL)
+	log.Debugf("Registering instance with url %s", reqURL)
 	_, rcode, err := getBody(reqURL+"/"+ins.Id(), e.UseJson)
 	if err != nil {
-		log.Error("Failed check if Instance=%s exists in app=%s, error: %s",
+		log.Errorf("Failed check if Instance=%s exists in app=%s, error: %s",
 			ins.Id(), ins.App, err.Error())
 		return err
 	}
 	if rcode == 200 {
-		log.Notice("Instance=%s already exists in App=%s, aborting registration", ins.Id(), ins.App)
+		log.Noticef("Instance=%s already exists in App=%s, aborting registration", ins.Id(), ins.App)
 		return nil
 	}
-	log.Notice("Instance=%s not yet registered with App=%s, registering.", ins.Id(), ins.App)
+	log.Noticef("Instance=%s not yet registered with App=%s, registering.", ins.Id(), ins.App)
 	return e.ReregisterInstance(ins)
 }
 
@@ -158,11 +158,11 @@ func (e *EurekaConnection) ReregisterInstance(ins *Instance) error {
 
 	body, rcode, err := postBody(reqURL, out, e.UseJson)
 	if err != nil {
-		log.Error("Could not complete registration, error: %s", err.Error())
+		log.Errorf("Could not complete registration, error: %s", err.Error())
 		return err
 	}
 	if rcode != 204 {
-		log.Warning("HTTP returned %d registering Instance=%s App=%s Body=\"%s\"", rcode,
+		log.Warningf("HTTP returned %d registering Instance=%s App=%s Body=\"%s\"", rcode,
 			ins.Id(), ins.App, string(body))
 		return fmt.Errorf("http returned %d possible failure registering instance\n", rcode)
 	}
@@ -177,7 +177,7 @@ func (e *EurekaConnection) ReregisterInstance(ins *Instance) error {
 func (e *EurekaConnection) GetInstance(app, insId string) (*Instance, error) {
 	slug := fmt.Sprintf("%s/%s/%s", EurekaURLSlugs["Apps"], app, insId)
 	reqURL := e.generateURL(slug)
-	log.Debug("Getting instance with url %s", reqURL)
+	log.Debugf("Getting instance with url %s", reqURL)
 	body, rcode, err := getBody(reqURL, e.UseJson)
 	if err != nil {
 		return nil, err
@@ -210,15 +210,15 @@ func (e *EurekaConnection) readInstanceInto(ins *Instance) error {
 func (e *EurekaConnection) DeregisterInstance(ins *Instance) error {
 	slug := fmt.Sprintf("%s/%s/%s", EurekaURLSlugs["Apps"], ins.App, ins.Id())
 	reqURL := e.generateURL(slug)
-	log.Debug("Deregistering instance with url %s", reqURL)
+	log.Debugf("Deregistering instance with url %s", reqURL)
 
 	rcode, err := deleteReq(reqURL)
 	if err != nil {
-		log.Error("Could not complete deregistration, error: %s", err.Error())
+		log.Errorf("Could not complete deregistration, error: %s", err.Error())
 		return err
 	}
 	if rcode != 204 {
-		log.Warning("HTTP returned %d deregistering Instance=%s App=%s", rcode, ins.Id(), ins.App)
+		log.Warningf("HTTP returned %d deregistering Instance=%s App=%s", rcode, ins.Id(), ins.App)
 		return fmt.Errorf("http returned %d possible failure deregistering instance\n", rcode)
 	}
 
@@ -232,14 +232,14 @@ func (e EurekaConnection) AddMetadataString(ins *Instance, key, value string) er
 
 	params := map[string]string{key: value}
 
-	log.Debug("Updating instance metadata url=%s metadata=%s", reqURL, params)
+	log.Debugf("Updating instance metadata url=%s metadata=%s", reqURL, params)
 	body, rcode, err := putKV(reqURL, params)
 	if err != nil {
-		log.Error("Could not complete update, error: %s", err.Error())
+		log.Errorf("Could not complete update, error: %s", err.Error())
 		return err
 	}
 	if rcode < 200 || rcode >= 300 {
-		log.Warning("HTTP returned %d updating metadata Instance=%s App=%s Body=\"%s\"", rcode,
+		log.Warningf("HTTP returned %d updating metadata Instance=%s App=%s Body=\"%s\"", rcode,
 			ins.Id(), ins.App, string(body))
 		return fmt.Errorf("http returned %d possible failure updating instance metadata ", rcode)
 	}
@@ -254,14 +254,14 @@ func (e EurekaConnection) UpdateInstanceStatus(ins *Instance, status StatusType)
 
 	params := map[string]string{"value": string(status)}
 
-	log.Debug("Updating instance status url=%s value=%s", reqURL, status)
+	log.Debugf("Updating instance status url=%s value=%s", reqURL, status)
 	body, rcode, err := putKV(reqURL, params)
 	if err != nil {
 		log.Error("Could not complete update, error: ", err.Error())
 		return err
 	}
 	if rcode < 200 || rcode >= 300 {
-		log.Warning("HTTP returned %d updating status Instance=%s App=%s Body=\"%s\"", rcode,
+		log.Warningf("HTTP returned %d updating status Instance=%s App=%s Body=\"%s\"", rcode,
 			ins.Id(), ins.App, string(body))
 		return fmt.Errorf("http returned %d possible failure updating instance status ", rcode)
 	}
@@ -273,19 +273,19 @@ func (e EurekaConnection) UpdateInstanceStatus(ins *Instance, status StatusType)
 func (e *EurekaConnection) HeartBeatInstance(ins *Instance) error {
 	slug := fmt.Sprintf("%s/%s/%s", EurekaURLSlugs["Apps"], ins.App, ins.Id())
 	reqURL := e.generateURL(slug)
-	log.Debug("Sending heartbeat with url %s", reqURL)
+	log.Debugf("Sending heartbeat with url %s", reqURL)
 	req, err := http.NewRequest("PUT", reqURL, nil)
 	if err != nil {
-		log.Error("Could not create request for heartbeat, error: %s", err.Error())
+		log.Errorf("Could not create request for heartbeat, error: %s", err.Error())
 		return err
 	}
 	_, rcode, err := netReq(req)
 	if err != nil {
-		log.Error("Error sending heartbeat for Instance=%s App=%s, error: %s", ins.Id(), ins.App, err.Error())
+		log.Errorf("Error sending heartbeat for Instance=%s App=%s, error: %s", ins.Id(), ins.App, err.Error())
 		return err
 	}
 	if rcode != 200 {
-		log.Error("Sending heartbeat for Instance=%s App=%s returned code %d", ins.Id(), ins.App, rcode)
+		log.Errorf("Sending heartbeat for Instance=%s App=%s returned code %d", ins.Id(), ins.App, rcode)
 		return fmt.Errorf("heartbeat returned code %d\n", rcode)
 	}
 	return nil

--- a/rpc.go
+++ b/rpc.go
@@ -21,13 +21,13 @@ var transport = &http.Transport{
 func postBody(reqURL string, reqBody []byte, isJson bool) ([]byte, int, error) {
 	req, err := http.NewRequest("POST", reqURL, bytes.NewReader(reqBody))
 	if err != nil {
-		log.Error("Could not create POST %s with body %s, error: %s", reqURL, string(reqBody), err.Error())
+		log.Errorf("Could not create POST %s with body %s, error: %s", reqURL, string(reqBody), err.Error())
 		return nil, -1, err
 	}
-	log.Debug("postBody: %s %s : %s\n", req.Method, req.URL, string(reqBody))
+	log.Debugf("postBody: %s %s : %s\n", req.Method, req.URL, string(reqBody))
 	body, rcode, err := netReqTyped(req, isJson)
 	if err != nil {
-		log.Error("Could not complete POST %s with body %s, error: %s", reqURL, string(reqBody), err.Error())
+		log.Errorf("Could not complete POST %s with body %s, error: %s", reqURL, string(reqBody), err.Error())
 		return nil, rcode, err
 	}
 	//eurekaCache.Flush()
@@ -40,15 +40,15 @@ func putKV(reqURL string, pairs map[string]string) ([]byte, int, error) {
 		params.Add(k, v)
 	}
 	parameterizedURL := reqURL + "?" + params.Encode()
-	log.Notice("Sending KV request with URL %s", parameterizedURL)
+	log.Noticef("Sending KV request with URL %s", parameterizedURL)
 	req, err := http.NewRequest("PUT", parameterizedURL, nil)
 	if err != nil {
-		log.Error("Could not create PUT %s, error: %s", reqURL, err.Error())
+		log.Errorf("Could not create PUT %s, error: %s", reqURL, err.Error())
 		return nil, -1, err
 	}
 	body, rcode, err := netReq(req) // TODO(cq) I think this can just be netReq() since there is no body
 	if err != nil {
-		log.Error("Could not complete PUT %s, error: %s", reqURL, err.Error())
+		log.Errorf("Could not complete PUT %s, error: %s", reqURL, err.Error())
 		return nil, rcode, err
 	}
 	return body, rcode, nil
@@ -57,12 +57,12 @@ func putKV(reqURL string, pairs map[string]string) ([]byte, int, error) {
 func getBody(reqURL string, isJson bool) ([]byte, int, error) {
 	req, err := http.NewRequest("GET", reqURL, nil)
 	if err != nil {
-		log.Error("Could not create GET %s, error: %s", reqURL, err.Error())
+		log.Errorf("Could not create GET %s, error: %s", reqURL, err.Error())
 		return nil, -1, err
 	}
 	body, rcode, err := netReqTyped(req, isJson)
 	if err != nil {
-		log.Error("Could not complete GET %s, error: %s", reqURL, err.Error())
+		log.Errorf("Could not complete GET %s, error: %s", reqURL, err.Error())
 		return nil, rcode, err
 	}
 	return body, rcode, nil
@@ -71,12 +71,12 @@ func getBody(reqURL string, isJson bool) ([]byte, int, error) {
 func deleteReq(reqURL string) (int, error) {
 	req, err := http.NewRequest("DELETE", reqURL, nil)
 	if err != nil {
-		log.Error("Could not create DELETE %s, error: %s", reqURL, err.Error())
+		log.Errorf("Could not create DELETE %s, error: %s", reqURL, err.Error())
 		return -1, err
 	}
 	_, rcode, err := netReq(req)
 	if err != nil {
-		log.Error("Could not complete DELETE %s, error: %s", reqURL, err.Error())
+		log.Errorf("Could not complete DELETE %s, error: %s", reqURL, err.Error())
 		return rcode, err
 	}
 	return rcode, nil
@@ -106,7 +106,7 @@ func netReq(req *http.Request) ([]byte, int, error) {
 		if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
 			// it's a transient network error so we sleep for a bit and try
 			// again in case it's a short-lived issue
-			log.Warning("Retrying after temporary network failure, error: %s",
+			log.Warningf("Retrying after temporary network failure, error: %s",
 				nerr.Error())
 			time.Sleep(10)
 		} else {
@@ -119,10 +119,10 @@ func netReq(req *http.Request) ([]byte, int, error) {
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Error("Failure reading request body, error: %s", err.Error())
+		log.Errorf("Failure reading request body, error: %s", err.Error())
 		return nil, -1, err
 	}
 	// At this point we're done and shit worked, simply return the bytes
-	log.Info("Got eureka response from url=%v", req.URL)
+	log.Infof("Got eureka response from url=%v", req.URL)
 	return body, resp.StatusCode, nil
 }


### PR DESCRIPTION
# Description 
This change needs to go live with similar change to alyx3
It's using the newest format of logging from non-backward compatible update from `op/go-logging` package.

# Backwards compatibility
Since `github.com/op/go-logging` did a breaking change we decided that we'll fix the code after upgreading that package. If you use old version of go-logging con't probably won't compile, but with newest version it should all be good
One should use Godep if is scared about that :(

# Reasoning
- wanted newest feature of op/go-logging
- only one version of go-logging package for apps using fargo

# Testing
This will affect mainly logs with formatting like `%s`. See if your logs looks ok after the change and are properly substituted

# Dependency consideration
After reviewing dependent hudl repos this shouldn't affect anything as those which one are using fargo uses Godep as well. For outside of hudl world if someone is using hudl/fargo and _not_ using Godep then probably they will have a problem with op/go-logging which this PR is fixing