### PR TITLE
Allow use of custom http.Client

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -11,6 +11,11 @@ import (
 	"time"
 )
 
+var HttpClient = &http.Client{
+	Transport: transport,
+	Timeout:   30 * time.Second,
+}
+
 var transport = &http.Transport{
 	Dial: (&net.Dialer{
 		Timeout: 5 * time.Second,
@@ -94,15 +99,10 @@ func netReqTyped(req *http.Request, isJson bool) ([]byte, int, error) {
 }
 
 func netReq(req *http.Request) ([]byte, int, error) {
-	// Send the request via a client
-	client := &http.Client{
-		Transport: transport,
-		Timeout:   30 * time.Second,
-	}
 	var resp *http.Response
 	var err error
 	for i := 0; i < 3; i++ {
-		resp, err = client.Do(req)
+		resp, err = HttpClient.Do(req)
 		if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
 			// it's a transient network error so we sleep for a bit and try
 			// again in case it's a short-lived issue

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -1,0 +1,45 @@
+package fargo
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type roundtripper struct {
+	TripCount int
+}
+
+func (r *roundtripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.TripCount++
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func TestHttpClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "Hello World")
+	}))
+	defer server.Close()
+
+	Convey("Given fargo.HttpClient is set to a custom client", t, func() {
+		rt := new(roundtripper)
+		HttpClient = &http.Client{
+			Transport: rt,
+		}
+
+		Convey("netReq uses that client to handle requests", func() {
+			req, err := http.NewRequest("GET", server.URL, nil)
+			So(err, ShouldBeNil)
+
+			respBody, respCode, err := netReq(req)
+			So(err, ShouldBeNil)
+			So(respCode, ShouldEqual, 200)
+			So(string(respBody), ShouldEqual, "Hello World")
+
+			So(rt.TripCount, ShouldEqual, 1)
+		})
+	})
+}


### PR DESCRIPTION
Hi,

I would like to use `fargo` to access an OAuth-protected instance of Eureka. In order to do that I need a way to switch out the `http.Client` that is being used to send requests. This PR adds that functionality. It should not affect the current behavior. I added a unit test to verify the new behavior.

Let me know if you have questions or feedback.

Thanks!