### PR TITLE
add InstanceId in Instance struct

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -75,6 +75,7 @@ type RegisterInstanceJson struct {
 // Instance [de]serializeable [to|from] Eureka XML
 type Instance struct {
 	XMLName          struct{} `xml:"instance" json:"-"`
+	InstanceId       string   `xml:"instanceId" json:"instanceId"`
 	HostName         string   `xml:"hostName" json:"hostName"`
 	App              string   `xml:"app" json:"app"`
 	IPAddr           string   `xml:"ipAddr" json:"ipAddr"`


### PR DESCRIPTION
missing the instanceId which lead the service registered without instanceId and can not be retrieved by the instanceId later.
