### PR TITLE
Accommodate non-Amazon data center info metadata

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -134,10 +134,17 @@ type AmazonMetadataType struct {
 	InstanceType     string `xml:"instance-type" json:"instance-type"`
 }
 
-// DataCenterInfo is only really useful when running in AWS.
+// DataCenterInfo indicates which type of data center hosts this instance
+// and conveys details about the instance's environment.
 type DataCenterInfo struct {
-	Name     string             `xml:"name" json:"name"`
-	Metadata AmazonMetadataType `xml:"metadata" json:"metadata"`
+	// Name indicates which type of data center hosts this instance.
+	Name string
+	// Metadata provides details specific to an Amazon data center,
+	// populated and honored when the Name field's value is "Amazon".
+	Metadata AmazonMetadataType
+	// AlternateMetadata provides details specific to a data center other than Amazon,
+	// populated and honored when the Name field's value is not "Amazon".
+	AlternateMetadata map[string]string
 }
 
 // LeaseInfo tells us about the renewal from Eureka, including how old it is.

--- a/struct.go
+++ b/struct.go
@@ -6,13 +6,13 @@ import (
 	"time"
 )
 
-// EurekaUrlSlugs is a map of resource names -> eureka URLs
+// EurekaUrlSlugs is a map of resource names->Eureka URLs.
 var EurekaURLSlugs = map[string]string{
 	"Apps":      "apps",
 	"Instances": "instances",
 }
 
-// EurekaConnection is the settings required to make eureka requests
+// EurekaConnection is the settings required to make Eureka requests.
 type EurekaConnection struct {
 	ServiceUrls    []string
 	ServicePort    int
@@ -26,30 +26,30 @@ type EurekaConnection struct {
 	UseJson        bool
 }
 
-// GetAppsResponseJson lets us deserialize the eureka/v2/apps response JSON--a wrapped GetAppsResponse
+// GetAppsResponseJson lets us deserialize the eureka/v2/apps response JSON—a wrapped GetAppsResponse.
 type GetAppsResponseJson struct {
 	Response *GetAppsResponse `json:"applications"`
 }
 
-// GetAppsResponse lets us deserialize the eureka/v2/apps response XML
+// GetAppsResponse lets us deserialize the eureka/v2/apps response XML.
 type GetAppsResponse struct {
 	Applications  []*Application `xml:"application" json:"application"`
 	AppsHashcode  string         `xml:"apps__hashcode" json:"apps__hashcode"`
 	VersionsDelta int            `xml:"versions__delta" json:"versions__delta"`
 }
 
-// Application deserializeable from Eureka JSON
+// Application deserializeable from Eureka JSON.
 type GetAppResponseJson struct {
 	Application Application `json:"application"`
 }
 
-// Application deserializeable from Eureka XML
+// Application deserializeable from Eureka XML.
 type Application struct {
 	Name      string      `xml:"name" json:"name"`
 	Instances []*Instance `xml:"instance" json:"instance"`
 }
 
-// StatusType is an enum of the different statuses allowed by Eureka
+// StatusType is an enum of the different statuses allowed by Eureka.
 type StatusType string
 
 // Supported statuses
@@ -67,12 +67,12 @@ const (
 	MyOwn  = "MyOwn"
 )
 
-// RegisterInstanceJson lets us serialize the eureka/v2/apps/<ins> request JSON--a wrapped Instance
+// RegisterInstanceJson lets us serialize the eureka/v2/apps/<ins> request JSON—a wrapped Instance.
 type RegisterInstanceJson struct {
 	Instance *Instance `json:"instance"`
 }
 
-// Instance [de]serializeable [to|from] Eureka XML
+// Instance [de]serializeable [to|from] Eureka XML.
 type Instance struct {
 	XMLName          struct{} `xml:"instance" json:"-"`
 	HostName         string   `xml:"hostName" json:"hostName"`
@@ -102,21 +102,22 @@ type Instance struct {
 	UniqueID func(i Instance) string `xml:"-" json:"-"`
 }
 
-// Port struct used for JSON [un]marshaling only
-// looks like: "port":{"@enabled":"true", "$":"7101"},
+// Port struct used for JSON [un]marshaling only.
+// An example:
+// 	"port":{"@enabled":"true", "$":"7101"}
 type Port struct {
 	Number  string `json:"$"`
 	Enabled string `json:"@enabled"`
 }
 
-// InstanceMetadata represents the eureka metadata, which is arbitrary XML. See
-// metadata.go for more info.
+// InstanceMetadata represents the eureka metadata, which is arbitrary XML.
+// See metadata.go for more info.
 type InstanceMetadata struct {
 	Raw    []byte `xml:",innerxml" json:"-"`
 	parsed map[string]interface{}
 }
 
-// AmazonMetadataType is information about AZ's, AMI's, and the AWS instance
+// AmazonMetadataType is information about AZ's, AMI's, and the AWS instance.
 // <xsd:complexType name="amazonMetdataType">
 // from http://docs.amazonwebservices.com/AWSEC2/latest/DeveloperGuide/index.html?AESDG-chapter-instancedata.html
 type AmazonMetadataType struct {
@@ -139,7 +140,7 @@ type DataCenterInfo struct {
 	Metadata AmazonMetadataType `xml:"metadata" json:"metadata"`
 }
 
-// LeaseInfo tells us about the renewal from Eureka, including how old it is
+// LeaseInfo tells us about the renewal from Eureka, including how old it is.
 type LeaseInfo struct {
 	RenewalIntervalInSecs int32 `xml:"renewalIntervalInSecs" json:"renewalIntervalInSecs"`
 	DurationInSecs        int32 `xml:"durationInSecs" json:"durationInSecs"`

--- a/tests/marshal_test.go
+++ b/tests/marshal_test.go
@@ -4,11 +4,13 @@ package fargo_test
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
-	"github.com/hudl/fargo"
-	. "github.com/smartystreets/goconvey/convey"
 	"io/ioutil"
 	"testing"
+
+	"github.com/hudl/fargo"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestJsonMarshal(t *testing.T) {
@@ -44,18 +46,118 @@ func TestJsonMarshal(t *testing.T) {
 }
 
 func TestMetadataMarshal(t *testing.T) {
-	Convey("Given an InstanceMetadata", t, func() {
+	Convey("Given an Instance with metadata", t, func() {
 		ins := &fargo.Instance{}
 		ins.SetMetadataString("key1", "value1")
 		ins.SetMetadataString("key2", "value2")
 
-		Convey("When the metadata are marshalled", func() {
+		Convey("When the metadata are marshalled as JSON", func() {
 			b, err := json.Marshal(&ins.Metadata)
-			fmt.Printf("(debug info b = %s)", b)
 
 			Convey("The marshalled JSON should have these values", func() {
-				So(string(b), ShouldEqual, `{"key1":"value1","key2":"value2"}`)
 				So(err, ShouldBeNil)
+				So(string(b), ShouldEqual, `{"key1":"value1","key2":"value2"}`)
+			})
+		})
+
+		Convey("When the metadata are marshalled as XML", func() {
+			b, err := xml.Marshal(&ins.Metadata)
+
+			Convey("The marshalled XML should have this value", func() {
+				So(err, ShouldBeNil)
+				So(string(b), ShouldBeIn,
+					"<InstanceMetadata><key1>value1</key1><key2>value2</key2></InstanceMetadata>",
+					"<InstanceMetadata><key2>value2</key2><key1>value1</key1></InstanceMetadata>")
+			})
+		})
+	})
+}
+
+func TestDataCenterInfoMarshal(t *testing.T) {
+	Convey("Given an Instance situated in a data center", t, func() {
+		ins := &fargo.Instance{}
+
+		Convey("When the data center name is \"Amazon\"", func() {
+			ins.DataCenterInfo.Name = fargo.Amazon
+			ins.DataCenterInfo.Metadata.InstanceID = "123"
+			ins.DataCenterInfo.Metadata.HostName = "expected.local"
+
+			Convey("When the data center info is marshalled as JSON", func() {
+				b, err := json.Marshal(&ins.DataCenterInfo)
+
+				Convey("The marshalled JSON should have these values", func() {
+					So(err, ShouldBeNil)
+					So(string(b), ShouldEqual, `{"name":"Amazon","metadata":{"ami-launch-index":"","local-hostname":"","availability-zone":"","instance-id":"123","public-ipv4":"","public-hostname":"","ami-manifest-path":"","local-ipv4":"","hostname":"expected.local","ami-id":"","instance-type":""}}`)
+
+					Convey("The value unmarshalled from JSON should have the same values as the original", func() {
+						d := fargo.DataCenterInfo{}
+						err := json.Unmarshal(b, &d)
+
+						So(err, ShouldBeNil)
+						So(d, ShouldResemble, ins.DataCenterInfo)
+					})
+				})
+			})
+
+			Convey("When the data center info is marshalled as XML", func() {
+				b, err := xml.Marshal(&ins.DataCenterInfo)
+
+				Convey("The marshalled XML should have this value", func() {
+					So(err, ShouldBeNil)
+					So(string(b), ShouldEqual, "<DataCenterInfo><name>Amazon</name><metadata><ami-launch-index></ami-launch-index><local-hostname></local-hostname><availability-zone></availability-zone><instance-id>123</instance-id><public-ipv4></public-ipv4><public-hostname></public-hostname><ami-manifest-path></ami-manifest-path><local-ipv4></local-ipv4><hostname>expected.local</hostname><ami-id></ami-id><instance-type></instance-type></metadata></DataCenterInfo>")
+
+					Convey("The value unmarshalled from XML should have the same values as the original", func() {
+						d := fargo.DataCenterInfo{}
+						err := xml.Unmarshal(b, &d)
+
+						So(err, ShouldBeNil)
+						So(d, ShouldResemble, ins.DataCenterInfo)
+					})
+				})
+			})
+		})
+
+		Convey("When the data center name is not \"Amazon\"", func() {
+			ins.DataCenterInfo.Name = fargo.MyOwn
+			ins.DataCenterInfo.AlternateMetadata = map[string]string{
+				"instanceId": "123",
+				"hostName":   "expected.local",
+			}
+
+			Convey("When the data center info is marshalled as JSON", func() {
+				b, err := json.Marshal(&ins.DataCenterInfo)
+
+				Convey("The marshalled JSON should have these values", func() {
+					So(err, ShouldBeNil)
+					So(string(b), ShouldEqual, `{"name":"MyOwn","metadata":{"hostName":"expected.local","instanceId":"123"}}`)
+
+					Convey("The value unmarshalled from JSON should have the same values as the original", func() {
+						d := fargo.DataCenterInfo{}
+						err := json.Unmarshal(b, &d)
+
+						So(err, ShouldBeNil)
+						So(d, ShouldResemble, ins.DataCenterInfo)
+					})
+				})
+			})
+
+			Convey("When the data center info is marshalled as XML", func() {
+				b, err := xml.Marshal(&ins.DataCenterInfo)
+
+				Convey("The marshalled XML should have this value", func() {
+					So(err, ShouldBeNil)
+					So(string(b), ShouldBeIn,
+						"<DataCenterInfo><name>MyOwn</name><metadata><hostName>expected.local</hostName><instanceId>123</instanceId></metadata></DataCenterInfo>",
+						"<DataCenterInfo><name>MyOwn</name><metadata><instanceId>123</instanceId><hostName>expected.local</hostName></metadata></DataCenterInfo>")
+
+					Convey("The value unmarshalled from XML should have the same values as the original", func() {
+						d := fargo.DataCenterInfo{}
+						err := xml.Unmarshal(b, &d)
+
+						So(err, ShouldBeNil)
+						So(d, ShouldResemble, ins.DataCenterInfo)
+					})
+				})
 			})
 		})
 	})


### PR DESCRIPTION
These proposed changes address #42, including tests to demonstrate the special marshaling policy for the `fargo.DataCenterInfo` struct.

Let me know if you think we should define a method on `DataCenterInfo` like `AddMetadataEntry(key, value string)` that would create the map for the `AlternateMetadata` field if it's still nil.