### PR TITLE
Ease interpretation of errors by HTTP status code

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,66 @@ package fargo
 
 // MIT Licensed (see README.md) - Copyright (c) 2013 Hudl <@Hudl>
 
+import (
+	"fmt"
+	"net/http"
+)
+
+type unsuccessfulHTTPResponse struct {
+	statusCode    int
+	messagePrefix string
+}
+
+func (u unsuccessfulHTTPResponse) Error() string {
+	return fmt.Sprint(u.messagePrefix, ", rcode = ", u.statusCode)
+}
+
+type unsuccessfulRegistrationResponse struct {
+	unsuccessfulHTTPResponse
+}
+
+type unsuccessfulDeregistrationResponse struct {
+	unsuccessfulHTTPResponse
+}
+
+type unsuccessfulUpdateResponse struct {
+	unsuccessfulHTTPResponse
+}
+
+type unsuccessfulMetadataUpdateResponse struct {
+	unsuccessfulHTTPResponse
+}
+
+type unsuccessfulRetrievalResponse struct {
+	unsuccessfulHTTPResponse
+}
+
+// InstanceWasInvalid returns true if the error arose during an instance registration attempt
+// due to Eureka rejecting the proposed instance as invalid.
+func InstanceWasInvalid(err error) bool {
+	if u, ok := err.(unsuccessfulRegistrationResponse); ok {
+		return u.statusCode == http.StatusBadRequest
+	}
+	return false
+}
+
+// InstanceWasMissing returns true if the error arose during an instance retrieval, status update,
+// metadata update, or deregistration attempt due to the target instance not being registered,
+// being unknown to Eureka.
+func InstanceWasMissing(err error) bool {
+	switch u := err.(type) {
+	case unsuccessfulDeregistrationResponse:
+		return u.statusCode == http.StatusNotFound
+	case unsuccessfulUpdateResponse:
+		return u.statusCode == http.StatusNotFound
+	case unsuccessfulMetadataUpdateResponse:
+		return u.statusCode == http.StatusInternalServerError
+	case unsuccessfulRetrievalResponse:
+		return u.statusCode == http.StatusNotFound
+	}
+	return false
+}
+
 type AppNotFoundError struct {
 	specific string
 }

--- a/net.go
+++ b/net.go
@@ -217,7 +217,7 @@ func (e *EurekaConnection) DeregisterInstance(ins *Instance) error {
 		log.Errorf("Could not complete deregistration, error: %s", err.Error())
 		return err
 	}
-	if rcode != http.StatusNoContent {
+	if rcode != http.StatusOK {
 		log.Warningf("HTTP returned %d deregistering Instance=%s App=%s", rcode, ins.Id(), ins.App)
 		return &unsuccessfulDeregistrationResponse{unsuccessfulHTTPResponse{rcode, "possible failure deregistering instance"}}
 	}

--- a/net.go
+++ b/net.go
@@ -131,7 +131,7 @@ func (e *EurekaConnection) RegisterInstance(ins *Instance) error {
 			ins.Id(), ins.App, err.Error())
 		return err
 	}
-	if rcode == 200 {
+	if rcode == http.StatusOK {
 		log.Noticef("Instance=%s already exists in App=%s, aborting registration", ins.Id(), ins.App)
 		return nil
 	}
@@ -164,7 +164,7 @@ func (e *EurekaConnection) ReregisterInstance(ins *Instance) error {
 	if rcode != 204 {
 		log.Warningf("HTTP returned %d registering Instance=%s App=%s Body=\"%s\"", rcode,
 			ins.Id(), ins.App, string(body))
-		return fmt.Errorf("http returned %d possible failure registering instance\n", rcode)
+		return &unsuccessfulRegistrationResponse{unsuccessfulHTTPResponse{rcode, "possible failure registering instance"}}
 	}
 
 	// read back our registration to pick up eureka-supplied values
@@ -182,8 +182,8 @@ func (e *EurekaConnection) GetInstance(app, insId string) (*Instance, error) {
 	if err != nil {
 		return nil, err
 	}
-	if rcode != 200 {
-		return nil, fmt.Errorf("Error getting instance, rcode = %d", rcode)
+	if rcode != http.StatusOK {
+		return nil, &unsuccessfulRetrievalResponse{unsuccessfulHTTPResponse{rcode, "unable to retrieve instance"}}
 	}
 	var ins *Instance
 	if e.UseJson {
@@ -217,9 +217,9 @@ func (e *EurekaConnection) DeregisterInstance(ins *Instance) error {
 		log.Errorf("Could not complete deregistration, error: %s", err.Error())
 		return err
 	}
-	if rcode != 204 {
+	if rcode != http.StatusNoContent {
 		log.Warningf("HTTP returned %d deregistering Instance=%s App=%s", rcode, ins.Id(), ins.App)
-		return fmt.Errorf("http returned %d possible failure deregistering instance\n", rcode)
+		return &unsuccessfulDeregistrationResponse{unsuccessfulHTTPResponse{rcode, "possible failure deregistering instance"}}
 	}
 
 	return nil
@@ -241,7 +241,7 @@ func (e EurekaConnection) AddMetadataString(ins *Instance, key, value string) er
 	if rcode < 200 || rcode >= 300 {
 		log.Warningf("HTTP returned %d updating metadata Instance=%s App=%s Body=\"%s\"", rcode,
 			ins.Id(), ins.App, string(body))
-		return fmt.Errorf("http returned %d possible failure updating instance metadata ", rcode)
+		return &unsuccessfulMetadataUpdateResponse{unsuccessfulHTTPResponse{rcode, "possible failure updating instance metadata"}}
 	}
 	ins.SetMetadataString(key, value)
 	return nil
@@ -263,7 +263,7 @@ func (e EurekaConnection) UpdateInstanceStatus(ins *Instance, status StatusType)
 	if rcode < 200 || rcode >= 300 {
 		log.Warningf("HTTP returned %d updating status Instance=%s App=%s Body=\"%s\"", rcode,
 			ins.Id(), ins.App, string(body))
-		return fmt.Errorf("http returned %d possible failure updating instance status ", rcode)
+		return &unsuccessfulUpdateResponse{unsuccessfulHTTPResponse{rcode, "possible failure updating instance status"}}
 	}
 	return nil
 }
@@ -284,9 +284,9 @@ func (e *EurekaConnection) HeartBeatInstance(ins *Instance) error {
 		log.Errorf("Error sending heartbeat for Instance=%s App=%s, error: %s", ins.Id(), ins.App, err.Error())
 		return err
 	}
-	if rcode != 200 {
+	if rcode != http.StatusOK {
 		log.Errorf("Sending heartbeat for Instance=%s App=%s returned code %d", ins.Id(), ins.App, rcode)
-		return fmt.Errorf("heartbeat returned code %d\n", rcode)
+		return &unsuccessfulUpdateResponse{unsuccessfulHTTPResponse{rcode, "heartbeat failed"}}
 	}
 	return nil
 }

--- a/tests/net_test.go
+++ b/tests/net_test.go
@@ -3,9 +3,10 @@ package fargo_test
 // MIT Licensed (see README.md) - Copyright (c) 2013 Hudl <@Hudl>
 
 import (
+	"testing"
+
 	"github.com/hudl/fargo"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
 )
 
 func TestConnectionCreation(t *testing.T) {
@@ -64,6 +65,7 @@ func TestRegistration(t *testing.T) {
 			}
 			err := e.HeartBeatInstance(&j)
 			So(err, ShouldNotBeNil)
+			So(fargo.InstanceWasMissing(err), ShouldBeTrue)
 		})
 		Convey("Register an instance to TESTAPP", t, func() {
 			Convey("Instance registers correctly", func() {
@@ -149,6 +151,7 @@ func DontTestDeregistration(t *testing.T) {
 		Convey("Instance cannot check in", func() {
 			err := e.HeartBeatInstance(&i)
 			So(err, ShouldNotBeNil)
+			So(fargo.InstanceWasMissing(err), ShouldBeTrue)
 		})
 	})
 }


### PR DESCRIPTION
Addressing #45, define two exported predicate functions to discern common reasons for instance-related operation failures.

Also, correct the expected HTTP status code in successful responses to deregistration requests.