### PR TITLE
Correct expected status code for deregistration

### DIFF
--- a/net.go
+++ b/net.go
@@ -217,7 +217,9 @@ func (e *EurekaConnection) DeregisterInstance(ins *Instance) error {
 		log.Errorf("Could not complete deregistration, error: %s", err.Error())
 		return err
 	}
-	if rcode != 204 {
+	// Eureka promises to return HTTP status code upon deregistration success, but fargo used to accept status code 204
+	// here instead. Accommodate both for backward compatibility with any fake or proxy Eureka stand-ins.
+	if rcode != 200 && rcode != 204 {
 		log.Warningf("HTTP returned %d deregistering Instance=%s App=%s", rcode, ins.Id(), ins.App)
 		return fmt.Errorf("http returned %d possible failure deregistering instance\n", rcode)
 	}


### PR DESCRIPTION
Per [the Eureka documentation](https://github.com/Netflix/eureka/wiki/Eureka-REST-operations) and the implementation in [method `com.netflix.eureka.resources.InstanceResource#cancelLease()`](https://github.com/Netflix/eureka/blob/master/eureka-core/src/main/java/com/netflix/eureka/resources/InstanceResource.java#L287), Eureka returns HTTP status code 200 to indicate successful deregistration of an instance, and not status code 204 as our `EurekaConnection`'s`DeregisterInstance` method had expected.

This change was originally proposed as part of #47.