### PR TITLE
Expose response HTTP status code in errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,29 @@ package fargo
 
 // MIT Licensed (see README.md) - Copyright (c) 2013 Hudl <@Hudl>
 
+import (
+	"fmt"
+)
+
+type unsuccessfulHTTPResponse struct {
+	statusCode    int
+	messagePrefix string
+}
+
+func (u *unsuccessfulHTTPResponse) Error() string {
+	return fmt.Sprint(u.messagePrefix, ", rcode = ", u.statusCode)
+}
+
+// HTTPResponseStatusCode extracts the HTTP status code for the response from Eureka that motivated
+// the supplied error, if any. If the returned present value is true, the returned code is an HTTP
+// status code.
+func HTTPResponseStatusCode(err error) (code int, present bool) {
+	if u, ok := err.(*unsuccessfulHTTPResponse); ok {
+		return u.statusCode, true
+	}
+	return 0, false
+}
+
 type AppNotFoundError struct {
 	specific string
 }

--- a/errors.go
+++ b/errors.go
@@ -12,7 +12,10 @@ type unsuccessfulHTTPResponse struct {
 }
 
 func (u *unsuccessfulHTTPResponse) Error() string {
-	return fmt.Sprint(u.messagePrefix, ", rcode = ", u.statusCode)
+	if len(u.messagePrefix) > 0 {
+		return fmt.Sprint(u.messagePrefix, ", rcode = ", u.statusCode)
+	}
+	return fmt.Sprint("rcode = ", u.statusCode)
 }
 
 // HTTPResponseStatusCode extracts the HTTP status code for the response from Eureka that motivated

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,34 @@
+package fargo
+
+// MIT Licensed (see README.md) - Copyright (c) 2013 Hudl <@Hudl>
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestHTTPResponseStatusCode(t *testing.T) {
+	tests := []struct {
+		input   error
+		present bool
+		code    int
+	}{
+		{nil, false, 0},
+		{errors.New("other"), false, 0},
+		{&unsuccessfulHTTPResponse{404, "missing"}, true, 404},
+	}
+	for _, test := range tests {
+		code, present := HTTPResponseStatusCode(test.input)
+		if present {
+			if !test.present {
+				t.Errorf("input %v: want absent, got code %d", test.input, code)
+				continue
+			}
+			if code != test.code {
+				t.Errorf("input %v: want %d, got %d", test.input, test.code, code)
+			}
+		} else if test.present {
+			t.Errorf("input %v: want code %d, got absent", test.input, test.code)
+		}
+	}
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -4,31 +4,49 @@ package fargo
 
 import (
 	"errors"
+	"strconv"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestHTTPResponseStatusCode(t *testing.T) {
-	tests := []struct {
-		input   error
-		present bool
-		code    int
-	}{
-		{nil, false, 0},
-		{errors.New("other"), false, 0},
-		{&unsuccessfulHTTPResponse{404, "missing"}, true, 404},
-	}
-	for _, test := range tests {
-		code, present := HTTPResponseStatusCode(test.input)
-		if present {
-			if !test.present {
-				t.Errorf("input %v: want absent, got code %d", test.input, code)
-				continue
-			}
-			if code != test.code {
-				t.Errorf("input %v: want %d, got %d", test.input, test.code, code)
-			}
-		} else if test.present {
-			t.Errorf("input %v: want code %d, got absent", test.input, test.code)
+	Convey("An nil error should have no HTTP status code", t, func() {
+		_, present := HTTPResponseStatusCode(nil)
+		So(present, ShouldBeFalse)
+	})
+	Convey("A foreign error should have no detectable HTTP status code", t, func() {
+		_, present := HTTPResponseStatusCode(errors.New("other"))
+		So(present, ShouldBeFalse)
+	})
+	Convey("A fargo error generated from a response from Eureka", t, func() {
+		verify := func(err *unsuccessfulHTTPResponse) {
+			Convey("should have the given HTTP status code", func() {
+				code, present := HTTPResponseStatusCode(err)
+				So(present, ShouldBeTrue)
+				So(code, ShouldEqual, err.statusCode)
+				Convey("should produce a message", func() {
+					msg := err.Error()
+					if len(err.messagePrefix) == 0 {
+						Convey("that lacks a prefx", func() {
+							So(msg, ShouldNotStartWith, ",")
+						})
+					} else {
+						Convey("that starts with the given prefix", func() {
+							So(msg, ShouldStartWith, err.messagePrefix)
+						})
+					}
+					Convey("that contains the status code in decimal notation", func() {
+						So(msg, ShouldContainSubstring, strconv.Itoa(err.statusCode))
+					})
+				})
+			})
 		}
-	}
+		Convey("with a message prefix", func() {
+			verify(&unsuccessfulHTTPResponse{500, "operation failed"})
+		})
+		Convey("without a message prefix", func() {
+			verify(&unsuccessfulHTTPResponse{statusCode: 500})
+		})
+	})
 }

--- a/tests/net_test.go
+++ b/tests/net_test.go
@@ -3,10 +3,32 @@ package fargo_test
 // MIT Licensed (see README.md) - Copyright (c) 2013 Hudl <@Hudl>
 
 import (
+	"fmt"
+	"net/http"
+	"testing"
+
 	"github.com/hudl/fargo"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
 )
+
+func shouldNotBearAnHTTPStatusCode(actual interface{}, expected ...interface{}) string {
+	if code, present := fargo.HTTPResponseStatusCode(actual.(error)); present {
+		return fmt.Sprintf("Expected: no HTTP status code\nActual:   %d", code)
+	}
+	return ""
+}
+
+func shouldBearHTTPStatusCode(actual interface{}, expected ...interface{}) string {
+	expectedCode := expected[0]
+	code, present := fargo.HTTPResponseStatusCode(actual.(error))
+	if !present {
+		return fmt.Sprintf("Expected: %d\nActual:   no HTTP status code", expectedCode)
+	}
+	if code != expectedCode {
+		return fmt.Sprintf("Expected: %d\nActual:   %d", expectedCode, code)
+	}
+	return ""
+}
 
 func TestConnectionCreation(t *testing.T) {
 	Convey("Pull applications", t, func() {
@@ -64,6 +86,7 @@ func TestRegistration(t *testing.T) {
 			}
 			err := e.HeartBeatInstance(&j)
 			So(err, ShouldNotBeNil)
+			So(err, shouldBearHTTPStatusCode, http.StatusNotFound)
 		})
 		Convey("Register an instance to TESTAPP", t, func() {
 			Convey("Instance registers correctly", func() {
@@ -149,6 +172,7 @@ func DontTestDeregistration(t *testing.T) {
 		Convey("Instance cannot check in", func() {
 			err := e.HeartBeatInstance(&i)
 			So(err, ShouldNotBeNil)
+			So(err, shouldBearHTTPStatusCode, http.StatusNotFound)
 		})
 	})
 }


### PR DESCRIPTION
For various operations involving HTTP requests against the Eureka server, allow callers to interpret surfaced failures by way of inspecting the HTTP response's status code.

This proposal is a subset of the preceding #47, also intended to address #45. Rather than [_fargo_ interpreting what the server's responses mean in the context of the attempted operation](https://github.com/hudl/fargo/pull/47#issuecomment-248730898), we leave that interpretation open to callers.