### PR TITLE
Supply the set of instances for a VIP address

### DIFF
--- a/net_test.go
+++ b/net_test.go
@@ -1,0 +1,215 @@
+package fargo
+
+// MIT Licensed (see README.md) - Copyright (c) 2013 Hudl <@Hudl>
+
+import (
+	"math/rand"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func instancePredicateFrom(t *testing.T, opts ...InstanceQueryOption) func(*Instance) bool {
+	var mergedOptions instanceQueryOptions
+	for _, o := range opts {
+		if err := o(&mergedOptions); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if pred := mergedOptions.predicate; pred != nil {
+		return pred
+	}
+	t.Fatal("no predicate available")
+	panic("unreachable")
+}
+
+type countingSource struct {
+	callCount uint
+	seed      int64
+}
+
+func (s *countingSource) Int63() int64 {
+	s.callCount++
+	return s.seed
+}
+
+func (s *countingSource) Seed(seed int64) {
+	s.seed = seed
+}
+
+func (s *countingSource) Reset() {
+	s.callCount = 0
+}
+
+func TestInstanceQueryOptions(t *testing.T) {
+	Convey("A status predicate", t, func() {
+		Convey("mandates a nonempty status", func() {
+			var opts instanceQueryOptions
+			err := WithStatus("")(&opts)
+			So(err, ShouldNotBeNil)
+			So(opts.predicate, ShouldBeNil)
+		})
+		matchesStatus := func(pred func(*Instance) bool, status StatusType) bool {
+			return pred(&Instance{Status: status})
+		}
+		Convey("matches a single status", func() {
+			var opts instanceQueryOptions
+			desiredStatus := UNKNOWN
+			err := WithStatus(desiredStatus)(&opts)
+			So(err, ShouldBeNil)
+			pred := opts.predicate
+			So(pred, ShouldNotBeNil)
+			So(matchesStatus(pred, desiredStatus), ShouldBeTrue)
+			for _, status := range []StatusType{UP, DOWN, STARTING, OUTOFSERVICE} {
+				So(status, ShouldNotEqual, desiredStatus)
+				So(matchesStatus(pred, status), ShouldBeFalse)
+			}
+		})
+		Convey("matches a set of states", func() {
+			var opts instanceQueryOptions
+			desiredStates := []StatusType{DOWN, OUTOFSERVICE}
+			for _, status := range desiredStates {
+				err := WithStatus(status)(&opts)
+				So(err, ShouldBeNil)
+			}
+			pred := opts.predicate
+			So(pred, ShouldNotBeNil)
+			for _, status := range desiredStates {
+				So(matchesStatus(pred, status), ShouldBeTrue)
+			}
+			for _, status := range []StatusType{UP, STARTING, UNKNOWN} {
+				So(desiredStates, ShouldNotContain, status)
+				So(matchesStatus(pred, status), ShouldBeFalse)
+			}
+		})
+	})
+	Convey("A shuffling directive", t, func() {
+		Convey("using the global Rand instance", func() {
+			var opts instanceQueryOptions
+			err := Shuffled()(&opts)
+			So(err, ShouldBeNil)
+			So(opts.intn, ShouldNotBeNil)
+			So(opts.intn(1), ShouldEqual, 0)
+		})
+		Convey("using a specific Rand instance", func() {
+			source := countingSource{}
+			var opts instanceQueryOptions
+			err := ShuffledWith(rand.New(&source))(&opts)
+			So(err, ShouldBeNil)
+			So(opts.intn, ShouldNotBeNil)
+			So(source.callCount, ShouldEqual, 0)
+			So(opts.intn(2), ShouldEqual, 0)
+			So(source.callCount, ShouldEqual, 1)
+		})
+	})
+}
+
+func TestFilterInstancesInApps(t *testing.T) {
+	Convey("A predicate should preserve only those instances", t, func() {
+		Convey("with status UP", func() {
+			areUp := instancePredicateFrom(t, ThatAreUp())
+			Convey("from an empty set of applications", func() {
+				So(filterInstancesInApps(nil, areUp), ShouldBeEmpty)
+			})
+			Convey("from a single application with no instances", func() {
+				So(filterInstancesInApps([]*Application{
+					&Application{},
+				}, areUp), ShouldBeEmpty)
+			})
+			Convey("from a single application with one DOWN instance", func() {
+				So(filterInstancesInApps([]*Application{
+					&Application{
+						Instances: []*Instance{&Instance{Status: DOWN}},
+					},
+				}, areUp), ShouldBeEmpty)
+			})
+			Convey("from a single application with one UP instance", func() {
+				instance := &Instance{Status: UP}
+				filtered := filterInstancesInApps([]*Application{
+					&Application{
+						Instances: []*Instance{instance},
+					},
+				}, areUp)
+				So(filtered, ShouldHaveLength, 1)
+				So(filtered, ShouldContain, instance)
+			})
+			Convey("from a single application with multiple instances", func() {
+				upInstance := &Instance{Status: UP}
+				justHasUpInstance := func(instances ...*Instance) {
+					filtered := filterInstancesInApps([]*Application{
+						&Application{
+							Instances: instances,
+						},
+					}, areUp)
+					So(filtered, ShouldHaveLength, 1)
+					So(filtered, ShouldContain, upInstance)
+				}
+				downInstance := &Instance{Status: DOWN}
+				Convey("with UP instance first", func() {
+					justHasUpInstance(upInstance, downInstance)
+				})
+				Convey("with UP instance last", func() {
+					justHasUpInstance(downInstance, upInstance)
+				})
+				Convey("with multiple UP instances", func() {
+					secondUpInstance := &Instance{Status: UP}
+					thirdUpInstance := &Instance{Status: UP}
+					filtered := filterInstancesInApps([]*Application{
+						&Application{
+							Instances: []*Instance{upInstance, downInstance, secondUpInstance, thirdUpInstance, &Instance{Status: OUTOFSERVICE}},
+						},
+					}, areUp)
+					So(filtered, ShouldHaveLength, 3)
+					So(filtered, ShouldContain, upInstance)
+					So(filtered, ShouldContain, secondUpInstance)
+					So(filtered, ShouldContain, thirdUpInstance)
+				})
+			})
+			Convey("from multiple applications", func() {
+				firstUpInstance := &Instance{Status: UP}
+				secondUpInstance := &Instance{Status: UP}
+				filtered := filterInstancesInApps([]*Application{
+					&Application{
+						Instances: []*Instance{firstUpInstance, &Instance{Status: OUTOFSERVICE}},
+					},
+					&Application{},
+					&Application{
+						Instances: []*Instance{&Instance{Status: DOWN}, secondUpInstance},
+					},
+					&Application{
+						Instances: []*Instance{&Instance{Status: UNKNOWN}},
+					},
+				}, areUp)
+				So(filtered, ShouldHaveLength, 2)
+				So(filtered, ShouldContain, firstUpInstance)
+				So(filtered, ShouldContain, secondUpInstance)
+			})
+		})
+		Convey("with status matching any of those designated", func() {
+			upInstance := &Instance{Status: UP}
+			downInstance := &Instance{Status: DOWN}
+			startingInstance := &Instance{Status: STARTING}
+			outOfServiceInstance := &Instance{Status: OUTOFSERVICE}
+			pred := instancePredicateFrom(t, WithStatus(DOWN), WithStatus(OUTOFSERVICE))
+			Convey("from a single application", func() {
+				Convey("with no matching instances", func() {
+					So(filterInstancesInApps([]*Application{
+						&Application{
+							Instances: []*Instance{upInstance, startingInstance},
+						},
+					}, pred), ShouldBeEmpty)
+				})
+				Convey("with two matching instances", func() {
+					filtered := filterInstancesInApps([]*Application{
+						&Application{
+							Instances: []*Instance{upInstance, downInstance, startingInstance, outOfServiceInstance},
+						},
+					}, pred)
+					So(filtered, ShouldHaveLength, 2)
+					So(filtered, ShouldContain, downInstance)
+					So(filtered, ShouldContain, outOfServiceInstance)
+				})
+			})
+		})
+	})
+}

--- a/struct.go
+++ b/struct.go
@@ -6,10 +6,12 @@ import (
 	"time"
 )
 
-// EurekaUrlSlugs is a map of resource names->Eureka URLs.
+// EurekaURLSlugs is a map of resource names->Eureka URLs.
 var EurekaURLSlugs = map[string]string{
-	"Apps":      "apps",
-	"Instances": "instances",
+	"Apps":                        "apps",
+	"Instances":                   "instances",
+	"InstancesByVIPAddress":       "vips",
+	"InstancesBySecureVIPAddress": "svips",
 }
 
 // EurekaConnection is the settings required to make Eureka requests.


### PR DESCRIPTION
Per the preceding discussion in #53, synchronously retrieve the instances registered with a given secure or insecure VIP address, optionally filtering and shuffling them too. This is a first step ("polling"), deferring the "consuming" and "caching" facilities for a subsequent patch.

Note that writing the code under test took a day or two, but writing the tests has been a month-long pursuit. It's not difficult to figure out how to exercise the new capabilities; what's painfully frustrating is trying to accommodate Euereka's replication and cache eviction delays.

Here are the concessions I've tried:
- Have the client talk to only a single Eureka server, rather than alternating between two or more.
- Use only a single Eureka server, with no peer replica.
- Adjust the `eureka.responseCacheAutoExpirationInSeconds` and `eureka.responseCacheUpdateIntervalMs` configuration parameters down to [negligible magnitudes](https://github.com/hudl/fargo/issues/53#issuecomment-258546297).  
Note that in Eureka version 1.1.147—which we use in the Docker-hosted tests—it's not possible to defeat the Eureka server's response cache entirely.
- Poll the Eureka server after writing to confirm that the intended changes eventually become visible.  
Unfortunately, if the code under test doesn't work, the tests will run forever, absent a timeout.
- Impose empirically-derived delays in the tests in between important write-read-compare steps.

The proposal here includes that final, remorseful hack: wait for an amount of time that seems to work often enough, where waiting any less works less reliably. It's the only one I could get to work. I am open to other ideas if this one is sufficiently distasteful.

Since two of these new tests take so long to run, I skip them when [`testing.Short`](https://golang.org/pkg/testing/#Short) is true (summoned via [_go test -short_](https://golang.org/cmd/go/#hdr-Description_of_testing_flags)). We might consider adding this short v. long sensitivity to other long-running test functions.
