### PR TITLE
Schedule updates to the set of instances registered with a VIP address

### DIFF
--- a/example_appupdate_test.go
+++ b/example_appupdate_test.go
@@ -9,7 +9,8 @@ import (
 	"github.com/hudl/fargo"
 )
 
-func ExampleEurekaConnection_ScheduleAppUpdates(e *fargo.EurekaConnection) {
+func ExampleEurekaConnection_ScheduleAppUpdates() {
+	e := makeConnection()
 	done := make(chan struct{})
 	time.AfterFunc(2*time.Minute, func() {
 		close(done)
@@ -26,7 +27,8 @@ func ExampleEurekaConnection_ScheduleAppUpdates(e *fargo.EurekaConnection) {
 	fmt.Printf("Done monitoring application %q.\n", name)
 }
 
-func ExampleAppSource_Latest(e *fargo.EurekaConnection) {
+func ExampleAppSource_Latest() {
+	e := makeConnection()
 	name := "my_app"
 	source := e.NewAppSource(name, false)
 	defer source.Stop()
@@ -40,7 +42,8 @@ func ExampleAppSource_Latest(e *fargo.EurekaConnection) {
 	}
 }
 
-func ExampleAppSource_CopyLatestTo(e *fargo.EurekaConnection) {
+func ExampleAppSource_CopyLatestTo() {
+	e := makeConnection()
 	name := "my_app"
 	source := e.NewAppSource(name, true)
 	defer source.Stop()

--- a/example_appupdate_test.go
+++ b/example_appupdate_test.go
@@ -1,13 +1,15 @@
-package fargo
+package fargo_test
 
 // MIT Licensed (see README.md) - Copyright (c) 2013 Hudl <@Hudl>
 
 import (
 	"fmt"
 	"time"
+
+	"github.com/hudl/fargo"
 )
 
-func ExampleEurekaConnection_ScheduleAppUpdates(e *EurekaConnection) {
+func ExampleEurekaConnection_ScheduleAppUpdates(e *fargo.EurekaConnection) {
 	done := make(chan struct{})
 	time.AfterFunc(2*time.Minute, func() {
 		close(done)
@@ -24,7 +26,7 @@ func ExampleEurekaConnection_ScheduleAppUpdates(e *EurekaConnection) {
 	fmt.Printf("Done monitoring application %q.\n", name)
 }
 
-func ExampleAppSource_Latest(e *EurekaConnection) {
+func ExampleAppSource_Latest(e *fargo.EurekaConnection) {
 	name := "my_app"
 	source := e.NewAppSource(name, false)
 	defer source.Stop()
@@ -38,11 +40,11 @@ func ExampleAppSource_Latest(e *EurekaConnection) {
 	}
 }
 
-func ExampleAppSource_CopyLatestTo(e *EurekaConnection) {
+func ExampleAppSource_CopyLatestTo(e *fargo.EurekaConnection) {
 	name := "my_app"
 	source := e.NewAppSource(name, true)
 	defer source.Stop()
-	var app Application
+	var app fargo.Application
 	if !source.CopyLatestTo(&app) {
 		fmt.Printf("No application named %q is available.\n", name)
 	}

--- a/example_common_test.go
+++ b/example_common_test.go
@@ -1,0 +1,14 @@
+package fargo_test
+
+// MIT Licensed (see README.md) - Copyright (c) 2013 Hudl <@Hudl>
+
+import "github.com/hudl/fargo"
+
+func makeConnection() fargo.EurekaConnection {
+	var c fargo.Config
+	c.Eureka.ServiceUrls = []string{"http://172.17.0.2:8080/eureka/v2"}
+	c.Eureka.ConnectTimeoutSeconds = 10
+	c.Eureka.PollIntervalSeconds = 30
+	c.Eureka.Retries = 3
+	return fargo.NewConnFromConfig(c)
+}

--- a/example_vipupdate_test.go
+++ b/example_vipupdate_test.go
@@ -1,0 +1,78 @@
+package fargo_test
+
+// MIT Licensed (see README.md) - Copyright (c) 2013 Hudl <@Hudl>
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hudl/fargo"
+)
+
+func ExampleEurekaConnection_ScheduleVIPAddressUpdates_manual() {
+	e := makeConnection()
+	done := make(chan struct{})
+	time.AfterFunc(2*time.Minute, func() {
+		close(done)
+	})
+	vipAddress := "my_vip"
+	// We only care about those instances that are available to receive requests.
+	updates, err := e.ScheduleVIPAddressUpdates(vipAddress, true, done, fargo.ThatAreUp, fargo.Shuffled)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Printf("Monitoring VIP address %q.\n", vipAddress)
+	for update := range updates {
+		if update.Err != nil {
+			fmt.Printf("Most recent request for VIP address %q's instances failed: %v\n", vipAddress, update.Err)
+			continue
+		}
+		fmt.Printf("VIP address %q has %d instances available.\n", vipAddress, len(update.Instances))
+	}
+	fmt.Printf("Done monitoring VIP address %q.\n", vipAddress)
+}
+
+func ExampleEurekaConnection_ScheduleVIPAddressUpdates_context() {
+	e := makeConnection()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	vipAddress := "my_vip"
+	// Look for instances that are in trouble.
+	updates, err := e.ScheduleVIPAddressUpdates(vipAddress, true, ctx.Done(), fargo.WithStatus(fargo.DOWN), fargo.WithStatus(fargo.OUTOFSERVICE))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Printf("Monitoring VIP address %q.\n", vipAddress)
+	for update := range updates {
+		if update.Err != nil {
+			fmt.Printf("Most recent request for VIP address %q's instances failed: %v\n", vipAddress, update.Err)
+			continue
+		}
+		fmt.Printf("VIP address %q has %d instances in trouble.\n", vipAddress, len(update.Instances))
+	}
+	fmt.Printf("Done monitoring VIP address %q.\n", vipAddress)
+}
+
+func ExampleEurekaConnection_ScheduleSecureVIPAddressUpdates_context() {
+	e := makeConnection()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	svipAddress := "my_vip"
+	updates, err := e.ScheduleSecureVIPAddressUpdates(svipAddress, true, ctx.Done(), fargo.ThatAreUp)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Printf("Monitoring secure VIP address %q.\n", svipAddress)
+	for update := range updates {
+		if update.Err != nil {
+			fmt.Printf("Most recent request for secure VIP address %q's instances failed: %v\n", svipAddress, update.Err)
+			continue
+		}
+		fmt.Printf("Secure VIP address %q has %d instances.\n", svipAddress, len(update.Instances))
+	}
+	fmt.Printf("Done monitoring secure VIP address %q.\n", svipAddress)
+}

--- a/net_test.go
+++ b/net_test.go
@@ -86,7 +86,7 @@ func TestInstanceQueryOptions(t *testing.T) {
 	Convey("A shuffling directive", t, func() {
 		Convey("using the global Rand instance", func() {
 			var opts instanceQueryOptions
-			err := Shuffled()(&opts)
+			err := Shuffled(&opts)
 			So(err, ShouldBeNil)
 			So(opts.intn, ShouldNotBeNil)
 			So(opts.intn(1), ShouldEqual, 0)
@@ -107,7 +107,7 @@ func TestInstanceQueryOptions(t *testing.T) {
 func TestFilterInstancesInApps(t *testing.T) {
 	Convey("A predicate should preserve only those instances", t, func() {
 		Convey("with status UP", func() {
-			areUp := instancePredicateFrom(t, ThatAreUp())
+			areUp := instancePredicateFrom(t, ThatAreUp)
 			Convey("from an empty set of applications", func() {
 				So(filterInstancesInApps(nil, areUp), ShouldBeEmpty)
 			})

--- a/net_test.go
+++ b/net_test.go
@@ -1,0 +1,215 @@
+package fargo
+
+// MIT Licensed (see README.md) - Copyright (c) 2013 Hudl <@Hudl>
+
+import (
+	"math/rand"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func instancePredicateFrom(t *testing.T, opts ...InstanceQueryOption) func(*Instance) bool {
+	var mergedOptions instanceQueryOptions
+	for _, o := range opts {
+		if err := o(&mergedOptions); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if pred := mergedOptions.predicate; pred != nil {
+		return pred
+	}
+	t.Fatal("no predicate available")
+	panic("unreachable")
+}
+
+type countingSource struct {
+	callCount uint
+	seed      int64
+}
+
+func (s *countingSource) Int63() int64 {
+	s.callCount++
+	return s.seed
+}
+
+func (s *countingSource) Seed(seed int64) {
+	s.seed = seed
+}
+
+func (s *countingSource) Reset() {
+	s.callCount = 0
+}
+
+func TestInstanceQueryOptions(t *testing.T) {
+	Convey("A status predicate", t, func() {
+		Convey("mandates a nonempty status", func() {
+			var opts instanceQueryOptions
+			err := WithStatus("")(&opts)
+			So(err, ShouldNotBeNil)
+			So(opts.predicate, ShouldBeNil)
+		})
+		matchesStatus := func(pred func(*Instance) bool, status StatusType) bool {
+			return pred(&Instance{Status: status})
+		}
+		Convey("matches a single status", func() {
+			var opts instanceQueryOptions
+			desiredStatus := UNKNOWN
+			err := WithStatus(desiredStatus)(&opts)
+			So(err, ShouldBeNil)
+			pred := opts.predicate
+			So(pred, ShouldNotBeNil)
+			So(matchesStatus(pred, desiredStatus), ShouldBeTrue)
+			for _, status := range []StatusType{UP, DOWN, STARTING, OUTOFSERVICE} {
+				So(status, ShouldNotEqual, desiredStatus)
+				So(matchesStatus(pred, status), ShouldBeFalse)
+			}
+		})
+		Convey("matches a set of states", func() {
+			var opts instanceQueryOptions
+			desiredStates := []StatusType{DOWN, OUTOFSERVICE}
+			for _, status := range desiredStates {
+				err := WithStatus(status)(&opts)
+				So(err, ShouldBeNil)
+			}
+			pred := opts.predicate
+			So(pred, ShouldNotBeNil)
+			for _, status := range desiredStates {
+				So(matchesStatus(pred, status), ShouldBeTrue)
+			}
+			for _, status := range []StatusType{UP, STARTING, UNKNOWN} {
+				So(desiredStates, ShouldNotContain, status)
+				So(matchesStatus(pred, status), ShouldBeFalse)
+			}
+		})
+	})
+	Convey("A shuffling directive", t, func() {
+		Convey("using the global Rand instance", func() {
+			var opts instanceQueryOptions
+			err := Shuffled()(&opts)
+			So(err, ShouldBeNil)
+			So(opts.intn, ShouldNotBeNil)
+			So(opts.intn(1), ShouldEqual, 0)
+		})
+		Convey("using a specific Rand instance", func() {
+			source := countingSource{}
+			var opts instanceQueryOptions
+			err := ShuffledWith(rand.New(&source))(&opts)
+			So(err, ShouldBeNil)
+			So(opts.intn, ShouldNotBeNil)
+			So(source.callCount, ShouldEqual, 0)
+			So(opts.intn(2), ShouldEqual, 0)
+			So(source.callCount, ShouldEqual, 1)
+		})
+	})
+}
+
+func TestFilterInstancesInApps(t *testing.T) {
+	Convey("A predicate should preserve only those instances", t, func() {
+		Convey("with status UP", func() {
+			areUp := instancePredicateFrom(t, ThatAreUp())
+			Convey("from an empty set of applications", func() {
+				So(filterInstancesInApps(nil, areUp), ShouldBeEmpty)
+			})
+			Convey("from a single application with no instances", func() {
+				So(filterInstancesInApps([]*Application{
+					&Application{},
+				}, areUp), ShouldBeEmpty)
+			})
+			Convey("from a single application with one DOWN instance", func() {
+				So(filterInstancesInApps([]*Application{
+					&Application{
+						Instances: []*Instance{&Instance{Status: DOWN}},
+					},
+				}, areUp), ShouldBeEmpty)
+			})
+			Convey("from a single application with one UP instance", func() {
+				instance := &Instance{Status: UP}
+				filtered := filterInstancesInApps([]*Application{
+					&Application{
+						Instances: []*Instance{instance},
+					},
+				}, areUp)
+				So(filtered, ShouldHaveLength, 1)
+				So(filtered, ShouldContain, instance)
+			})
+			Convey("from a single application with multiple instances", func() {
+				upInstance := &Instance{Status: UP}
+				justHasUpInstance := func(instances ...*Instance) {
+					filtered := filterInstancesInApps([]*Application{
+						&Application{
+							Instances: instances,
+						},
+					}, areUp)
+					So(filtered, ShouldHaveLength, 1)
+					So(filtered, ShouldContain, upInstance)
+				}
+				downInstance := &Instance{Status: DOWN}
+				Convey("with UP instance first", func() {
+					justHasUpInstance(upInstance, downInstance)
+				})
+				Convey("with UP instance last", func() {
+					justHasUpInstance(downInstance, upInstance)
+				})
+				Convey("with multiple UP instances", func() {
+					secondUpInstance := &Instance{Status: UP}
+					thirdUpInstance := &Instance{Status: UP}
+					filtered := filterInstancesInApps([]*Application{
+						&Application{
+							Instances: []*Instance{upInstance, downInstance, secondUpInstance, thirdUpInstance, &Instance{Status: OUTOFSERVICE}},
+						},
+					}, areUp)
+					So(filtered, ShouldHaveLength, 3)
+					So(filtered, ShouldContain, upInstance)
+					So(filtered, ShouldContain, secondUpInstance)
+					So(filtered, ShouldContain, thirdUpInstance)
+				})
+			})
+			Convey("from multiple applications", func() {
+				firstUpInstance := &Instance{Status: UP}
+				secondUpInstance := &Instance{Status: UP}
+				filtered := filterInstancesInApps([]*Application{
+					&Application{
+						Instances: []*Instance{firstUpInstance, &Instance{Status: OUTOFSERVICE}},
+					},
+					&Application{},
+					&Application{
+						Instances: []*Instance{&Instance{Status: DOWN}, secondUpInstance},
+					},
+					&Application{
+						Instances: []*Instance{&Instance{Status: UNKNOWN}},
+					},
+				}, areUp)
+				So(filtered, ShouldHaveLength, 2)
+				So(filtered, ShouldContain, firstUpInstance)
+				So(filtered, ShouldContain, secondUpInstance)
+			})
+		})
+		Convey("with status matching any of those designated", func() {
+			upInstance := &Instance{Status: UP}
+			downInstance := &Instance{Status: DOWN}
+			startingInstance := &Instance{Status: STARTING}
+			outOfServiceInstance := &Instance{Status: OUTOFSERVICE}
+			pred := instancePredicateFrom(t, WithStatus(DOWN), WithStatus(OUTOFSERVICE))
+			Convey("from a single application", func() {
+				Convey("with no matching instances", func() {
+					So(filterInstancesInApps([]*Application{
+						&Application{
+							Instances: []*Instance{upInstance, startingInstance},
+						},
+					}, pred), ShouldBeEmpty)
+				})
+				Convey("with two matching instances", func() {
+					filtered := filterInstancesInApps([]*Application{
+						&Application{
+							Instances: []*Instance{upInstance, downInstance, startingInstance, outOfServiceInstance},
+						},
+					}, pred)
+					So(filtered, ShouldHaveLength, 2)
+					So(filtered, ShouldContain, downInstance)
+					So(filtered, ShouldContain, outOfServiceInstance)
+				})
+			})
+		})
+	})
+}

--- a/struct.go
+++ b/struct.go
@@ -6,10 +6,12 @@ import (
 	"time"
 )
 
-// EurekaUrlSlugs is a map of resource names->Eureka URLs.
+// EurekaURLSlugs is a map of resource names->Eureka URLs.
 var EurekaURLSlugs = map[string]string{
-	"Apps":      "apps",
-	"Instances": "instances",
+	"Apps":                        "apps",
+	"Instances":                   "instances",
+	"InstancesByVIPAddress":       "vips",
+	"InstancesBySecureVIPAddress": "svips",
 }
 
 // EurekaConnection is the settings required to make Eureka requests.

--- a/tests/net_test.go
+++ b/tests/net_test.go
@@ -149,7 +149,7 @@ func TestGetSingleInstanceByVIPAddress(t *testing.T) {
 			So(instances, ShouldHaveLength, 1)
 			So(instances[0].VipAddress, ShouldEqual, vipAddress)
 			Convey("requesting the instances by that VIP address with status UP should provide that one", func() {
-				instances, err := e.GetInstancesByVIPAddress(vipAddress, fargo.ThatAreUp())
+				instances, err := e.GetInstancesByVIPAddress(vipAddress, fargo.ThatAreUp)
 				So(err, ShouldBeNil)
 				So(instances, ShouldHaveLength, 1)
 				So(instances[0].VipAddress, ShouldEqual, vipAddress)
@@ -165,7 +165,7 @@ func TestGetSingleInstanceByVIPAddress(t *testing.T) {
 						So(instances, ShouldHaveLength, 1)
 						Convey("And selecting instances with status UP should provide none", func() {
 							// Ensure that we tolerate a nil option safely.
-							instances, err := e.GetInstancesByVIPAddress(vipAddress, fargo.ThatAreUp(), nil)
+							instances, err := e.GetInstancesByVIPAddress(vipAddress, fargo.ThatAreUp, nil)
 							So(err, ShouldBeNil)
 							So(instances, ShouldBeEmpty)
 						})


### PR DESCRIPTION
Per the preceding discussion in #53, and sitting on top of #54, poll the instances for a VIP address  periodically. This implements the "consuming" capability mentioned in #53, with a contraction in the method names down to `EurekaConnection.ScheduleVIPAddressUpdates` and `EurekaConnection.ScheduleSecureVIPAddressUpdates`, not mentioning the word "instance" there.

I used the same ["functional options" technique](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) first appearing in #54 for the following options that one can supply to `GetInstancesByVIPAddress`, `GetInstancesBySecureVIPAddress`, `ScheduleVIPAddressUpdates`, and `ScheduleSecureVIPAddressUpdates`:
- `WithStatus`
- `ThatAreUp`
- `Shuffled`
- `ShuffledWith`

I intend to apply those options to the "caching" factory functions as well.