### PR TITLE
Collapse secure VIP address functions by parameter

### DIFF
--- a/example_instancesetsource_test.go
+++ b/example_instancesetsource_test.go
@@ -12,7 +12,7 @@ import (
 func ExampleInstanceSetSource_Latest_outcomes() {
 	e := makeConnection()
 	vipAddress := "my_vip"
-	source, err := e.NewInstanceSetSourceForVIPAddress(vipAddress, false, fargo.ThatAreUp)
+	source, err := e.NewInstanceSetSourceForVIPAddress(vipAddress, false, false, fargo.ThatAreUp)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -36,7 +36,7 @@ func ExampleInstanceSetSource_Latest_outcomes() {
 func ExampleInstanceSetSource_Latest_compare() {
 	e := makeConnection()
 	svipAddress := "my_vip"
-	source, err := e.NewInstanceSetSourceForSecureVIPAddress(svipAddress, true, fargo.WithStatus(fargo.DOWN), fargo.WithStatus(fargo.OUTOFSERVICE))
+	source, err := e.NewInstanceSetSourceForVIPAddress(svipAddress, true, true, fargo.WithStatus(fargo.DOWN), fargo.WithStatus(fargo.OUTOFSERVICE))
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/example_vipupdate_test.go
+++ b/example_vipupdate_test.go
@@ -18,7 +18,7 @@ func ExampleEurekaConnection_ScheduleVIPAddressUpdates_manual() {
 	})
 	vipAddress := "my_vip"
 	// We only care about those instances that are available to receive requests.
-	updates, err := e.ScheduleVIPAddressUpdates(vipAddress, true, done, fargo.ThatAreUp, fargo.Shuffled)
+	updates, err := e.ScheduleVIPAddressUpdates(vipAddress, false, true, done, fargo.ThatAreUp, fargo.Shuffled)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -40,7 +40,7 @@ func ExampleEurekaConnection_ScheduleVIPAddressUpdates_context() {
 	defer cancel()
 	vipAddress := "my_vip"
 	// Look for instances that are in trouble.
-	updates, err := e.ScheduleVIPAddressUpdates(vipAddress, true, ctx.Done(), fargo.WithStatus(fargo.DOWN), fargo.WithStatus(fargo.OUTOFSERVICE))
+	updates, err := e.ScheduleVIPAddressUpdates(vipAddress, false, true, ctx.Done(), fargo.WithStatus(fargo.DOWN), fargo.WithStatus(fargo.OUTOFSERVICE))
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -61,7 +61,7 @@ func ExampleEurekaConnection_ScheduleSecureVIPAddressUpdates_context() {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	svipAddress := "my_vip"
-	updates, err := e.ScheduleSecureVIPAddressUpdates(svipAddress, true, ctx.Done(), fargo.ThatAreUp)
+	updates, err := e.ScheduleVIPAddressUpdates(svipAddress, true, true, ctx.Done(), fargo.ThatAreUp)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/tests/net_test.go
+++ b/tests/net_test.go
@@ -121,12 +121,12 @@ func TestGetInstancesByNonexistentVIPAddress(t *testing.T) {
 	for _, e.UseJson = range []bool{false, true} {
 		Convey("Get instances by VIP address", t, func() {
 			Convey("when the VIP address has no instances", func() {
-				instances, err := e.GetInstancesByVIPAddress("nonexistent")
+				instances, err := e.GetInstancesByVIPAddress("nonexistent", false)
 				So(err, ShouldBeNil)
 				So(instances, ShouldBeEmpty)
 			})
 			Convey("when the secure VIP address has no instances", func() {
-				instances, err := e.GetInstancesBySecureVIPAddress("nonexistent")
+				instances, err := e.GetInstancesByVIPAddress("nonexistent", true)
 				So(err, ShouldBeNil)
 				So(instances, ShouldBeEmpty)
 			})
@@ -144,12 +144,12 @@ func TestGetSingleInstanceByVIPAddress(t *testing.T) {
 	for _, e.UseJson = range []bool{false, true} {
 		Convey("When the VIP address has one instance", t, withRegisteredInstance(&e, func(instance *fargo.Instance) {
 			time.Sleep(cacheDelay)
-			instances, err := e.GetInstancesByVIPAddress(vipAddress)
+			instances, err := e.GetInstancesByVIPAddress(vipAddress, false)
 			So(err, ShouldBeNil)
 			So(instances, ShouldHaveLength, 1)
 			So(instances[0].VipAddress, ShouldEqual, vipAddress)
 			Convey("requesting the instances by that VIP address with status UP should provide that one", func() {
-				instances, err := e.GetInstancesByVIPAddress(vipAddress, fargo.ThatAreUp)
+				instances, err := e.GetInstancesByVIPAddress(vipAddress, false, fargo.ThatAreUp)
 				So(err, ShouldBeNil)
 				So(instances, ShouldHaveLength, 1)
 				So(instances[0].VipAddress, ShouldEqual, vipAddress)
@@ -160,7 +160,7 @@ func TestGetSingleInstanceByVIPAddress(t *testing.T) {
 					So(err, ShouldBeNil)
 					Convey("selecting instances with that other status should provide that one", func() {
 						time.Sleep(cacheDelay)
-						instances, err := e.GetInstancesByVIPAddress(vipAddress, fargo.WithStatus(otherStatus))
+						instances, err := e.GetInstancesByVIPAddress(vipAddress, false, fargo.WithStatus(otherStatus))
 						So(err, ShouldBeNil)
 						So(instances, ShouldHaveLength, 1)
 						Convey("And selecting instances with status UP should provide none", func() {
@@ -177,7 +177,7 @@ func TestGetSingleInstanceByVIPAddress(t *testing.T) {
 			Convey("requesting the instances by that VIP address should provide that one", func() {
 				time.Sleep(cacheDelay)
 				// Ensure that we tolerate a nil option safely.
-				instances, err := e.GetInstancesBySecureVIPAddress(vipAddress, nil)
+				instances, err := e.GetInstancesByVIPAddress(vipAddress, true, nil)
 				So(err, ShouldBeNil)
 				So(instances, ShouldHaveLength, 1)
 				So(instances[0].SecureVipAddress, ShouldEqual, vipAddress)


### PR DESCRIPTION
Addressing #53 and following up on [a suggestion](https://github.com/hudl/fargo/pull/57#discussion_r95124370) from #57, rather than exporting separate functions for querying insecure and secure VIP addresses, use one function for each purpose that demands a parameter designating whether the VIP address is secure or not.