### PR TITLE
Introducing a Logger interface for flexibility.

### DIFF
--- a/log.go
+++ b/log.go
@@ -6,11 +6,44 @@ import (
 	"github.com/op/go-logging"
 )
 
-var log = logging.MustGetLogger("fargo")
-var metadataLog = logging.MustGetLogger("fargo.metadata")
-var marshalLog = logging.MustGetLogger("fargo.marshal")
+type Logger interface {
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Panic(args ...interface{})
+	Panicf(format string, args ...interface{})
+	Critical(args ...interface{})
+	Criticalf(format string, args ...interface{})
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Warning(args ...interface{})
+	Warningf(format string, args ...interface{})
+	Notice(args ...interface{})
+	Noticef(format string, args ...interface{})
+	Info(args ...interface{})
+	Infof(format string, args ...interface{})
+	Debug(args ...interface{})
+	Debugf(format string, args ...interface{})
+}
+
+var log, metadataLog, marshalLog Logger
+
+func SetLogger(l Logger) {
+	log = l
+}
+
+func SetMarshalLogger(l Logger) {
+	metadataLog = l
+}
+
+func SetMetadataLogger(l Logger) {
+	marshalLog = l
+}
 
 func init() {
+	SetLogger(logging.MustGetLogger("fargo"))
+	SetMarshalLogger(logging.MustGetLogger("fargo.metadata"))
+	SetMetadataLogger(logging.MustGetLogger("fargo.marshal"))
+
 	logging.SetLevel(logging.WARNING, "fargo.metadata")
 	logging.SetLevel(logging.WARNING, "fargo.marshal")
 }


### PR DESCRIPTION
Hi guys,

I was wondering if you would be interested in this PR to open up the logging used by Fargo?

I think providing this interface should allow consumers to roll their own logging solution if desired. That is, consumers may not be using `op/go-logging` and therefore can pass a wrapper to the new `Set*` funcs. This wrapper acts as a shim bridging the logging solution they're using.

I'm quite new to Go so there may have been a better way of opening up Fargo's logger flexibility. Please let me know and I can look into that.

Also, I matched all log levels offered by `op/go-logging` which _does_ make the interface a little verbose. I'm aware Fargo is only using a few of the log levels internally and so the Fargo interface could have a few methods removed for brevity.