### PR TITLE
Make less noise in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ approximately 30 seconds later.
 
 If you are adding new packages to godep you may want to update the `hudloss/fargo` image first.
 
+# Logging
+To enable verbose logging, set the environment variable `FARGO_VERBOSE`
+
 # Known Issues
 
 Until [this PR](https://github.com/mitchellh/vagrant/pull/2742) is in an

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ approximately 30 seconds later.
 If you are adding new packages to godep you may want to update the `hudloss/fargo` image first.
 
 # Logging
-To enable verbose logging, set the environment variable `FARGO_VERBOSE`
+To change the verbosity of fargo logging, set the environment variable FARGO_LOG_LEVEL to DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL
+INFO is the default.
 
 # Known Issues
 

--- a/log.go
+++ b/log.go
@@ -3,6 +3,7 @@ package fargo
 // MIT Licensed (see README.md) - Copyright (c) 2013 Hudl <@Hudl>
 
 import (
+	"os"
 	"github.com/op/go-logging"
 )
 
@@ -11,6 +12,9 @@ var metadataLog = logging.MustGetLogger("fargo.metadata")
 var marshalLog = logging.MustGetLogger("fargo.marshal")
 
 func init() {
+	if len(os.Getenv("FARGO_VERBOSE")) > 0 {
+		logging.SetLevel(logging.DEBUG, "")
+	}
 	logging.SetLevel(logging.WARNING, "fargo.metadata")
 	logging.SetLevel(logging.WARNING, "fargo.marshal")
 }

--- a/log.go
+++ b/log.go
@@ -12,6 +12,7 @@ var log = logging.MustGetLogger("fargo")
 var metadataLog = logging.MustGetLogger("fargo.metadata")
 var marshalLog = logging.MustGetLogger("fargo.marshal")
 var logLevel = logging.INFO
+
 func init() {
 	switch levelOverride := strings.ToUpper(os.Getenv("FARGO_LOG_LEVEL")); levelOverride {
 		case "DEBUG":

--- a/log.go
+++ b/log.go
@@ -4,17 +4,31 @@ package fargo
 
 import (
 	"os"
+	"strings"
 	"github.com/op/go-logging"
 )
 
 var log = logging.MustGetLogger("fargo")
 var metadataLog = logging.MustGetLogger("fargo.metadata")
 var marshalLog = logging.MustGetLogger("fargo.marshal")
-
+var logLevel = logging.INFO
 func init() {
-	if len(os.Getenv("FARGO_VERBOSE")) > 0 {
-		logging.SetLevel(logging.DEBUG, "")
-	}
+	switch levelOverride := strings.ToUpper(os.Getenv("FARGO_LOG_LEVEL")); levelOverride {
+		case "DEBUG":
+			logLevel = logging.DEBUG
+		case "INFO":
+			logLevel = logging.INFO
+		case "NOTICE":
+			logLevel = logging.NOTICE
+		case "WARNING":
+			logLevel = logging.WARNING
+		case "ERROR":
+			logLevel = logging.ERROR
+		case "CRITICAL":
+			logLevel = logging.CRITICAL
+ 	}
+	logging.SetLevel(logLevel, "")
+
 	logging.SetLevel(logging.WARNING, "fargo.metadata")
 	logging.SetLevel(logging.WARNING, "fargo.marshal")
 }

--- a/rpc.go
+++ b/rpc.go
@@ -123,6 +123,6 @@ func netReq(req *http.Request) ([]byte, int, error) {
 		return nil, -1, err
 	}
 	// At this point we're done and shit worked, simply return the bytes
-	log.Infof("Got eureka response from url=%v", req.URL)
+	log.Debugf("Got eureka response from url=%v", req.URL)
 	return body, resp.StatusCode, nil
 }

--- a/rpc.go
+++ b/rpc.go
@@ -123,6 +123,6 @@ func netReq(req *http.Request) ([]byte, int, error) {
 		return nil, -1, err
 	}
 	// At this point we're done and shit worked, simply return the bytes
-	log.Debugf("Got eureka response from url=%v", req.URL)
+	log.Infof("Got eureka response from url=%v", req.URL)
 	return body, resp.StatusCode, nil
 }


### PR DESCRIPTION
The `Got eureka response from url` log message is very noisy. It logs every 15 seconds.

We use sumologic so we're paying by log volume and this message isn't helpful typically.

I've added the ability to adjust the desired verbosity using the `FARGO_LOG_LEVEL` environment variable. Setting it to DEBUG, INFO, NOTICE, WARNING, ERROR, or CRITICAL will determine what gets logged.