### PR TITLE
Make server application context variable for DNS discovery

### DIFF
--- a/config.go
+++ b/config.go
@@ -39,6 +39,7 @@ type eureka struct {
 	PreferSameZone        bool     // default false
 	RegisterWithEureka    bool     // default false
 	Retries               int      // default 3
+	ServerContext         string   // default "eureka/v2"
 }
 
 // ReadConfig from a file location. Minimal error handling. Just bails and passes up
@@ -66,5 +67,8 @@ func (c *Config) fillDefaults() {
 	}
 	if c.Eureka.PollIntervalSeconds == 0 {
 		c.Eureka.PollIntervalSeconds = 30
+	}
+	if c.Eureka.ServerContext == "" {
+		c.Eureka.ServerContext = "eureka/v2"
 	}
 }

--- a/connection.go
+++ b/connection.go
@@ -20,7 +20,7 @@ func (e *EurekaConnection) SelectServiceURL() string {
 		e.discoveryTtl = make(chan struct{}, 1)
 	}
 	if e.DNSDiscovery && len(e.discoveryTtl) == 0 {
-		servers, ttl, err := discoverDNS(e.DiscoveryZone, e.ServicePort)
+		servers, ttl, err := discoverDNS(e.DiscoveryZone, e.ServicePort, e.ServerContext)
 		if err != nil {
 			return choice(e.ServiceUrls)
 		}
@@ -68,6 +68,7 @@ func NewConnFromConfig(conf Config) (c EurekaConnection) {
 		log.Warning("UseDNSForServiceUrls is an experimental option")
 		c.DNSDiscovery = true
 		c.DiscoveryZone = conf.Eureka.DNSDiscoveryZone
+		c.ServerContext = conf.Eureka.ServerContext
 	}
 	return c
 }

--- a/dns_discover.go
+++ b/dns_discover.go
@@ -14,7 +14,7 @@ const azURL = "http://169.254.169.254/latest/meta-data/placement/availability-zo
 
 var ErrNotInAWS = fmt.Errorf("Not in AWS")
 
-func discoverDNS(domain string, port int) (servers []string, ttl time.Duration, err error) {
+func discoverDNS(domain string, port int, context string) (servers []string, ttl time.Duration, err error) {
 	r, _ := region()
 
 	// all DNS queries must use the FQDN
@@ -35,7 +35,7 @@ func discoverDNS(domain string, port int) (servers []string, ttl time.Duration, 
 		}
 		for _, instance := range instances {
 			// format the service URL
-			servers = append(servers, fmt.Sprintf("http://%s:%d/eureka/v2", instance, port))
+			servers = append(servers, fmt.Sprintf("http://%s:%d/%s", instance, port, context))
 		}
 	}
 	return

--- a/dns_discover_test.go
+++ b/dns_discover_test.go
@@ -46,7 +46,7 @@ func TestGetNetflixTestDomain(t *testing.T) {
 		})
 	})
 	Convey("Autodiscover discoverytest.netflix.net.", t, func() {
-		servers, ttl, err := discoverDNS("discoverytest.netflix.net", 7001)
+		servers, ttl, err := discoverDNS("discoverytest.netflix.net", 7001, "")
 		So(ttl, ShouldEqual, 60*time.Second)
 		So(err, ShouldBeNil)
 		So(len(servers), ShouldEqual, 6)

--- a/struct.go
+++ b/struct.go
@@ -25,6 +25,7 @@ type EurekaConnection struct {
 	DNSDiscovery   bool
 	DiscoveryZone  string
 	discoveryTtl   chan struct{}
+	ServerContext  string
 	UseJson        bool
 }
 


### PR DESCRIPTION
Right now server application context for DNS ServiceURLs discovery is hardcoded to `eureka/v2` while it could be set to a different value on the server side.
This simple patch makes it configurable.