### PR TITLE
Add property instanceId and optimize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.test
 eureka
 .vagrant/
+.idea/

--- a/config.go
+++ b/config.go
@@ -47,7 +47,7 @@ type eureka struct {
 func ReadConfig(loc string) (conf Config, err error) {
 	err = gcfg.ReadFileInto(&conf, loc)
 	if err != nil {
-		log.Criticalf("Unable to read config file Error: %s", err.Error())
+		log.Warningf("Unable to read config file Error: %s", err.Error())
 		return conf, err
 	}
 	conf.fillDefaults()

--- a/config.go
+++ b/config.go
@@ -47,7 +47,7 @@ type eureka struct {
 func ReadConfig(loc string) (conf Config, err error) {
 	err = gcfg.ReadFileInto(&conf, loc)
 	if err != nil {
-		log.Warningf("Unable to read config file Error: %s", err.Error())
+		log.Criticalf("Unable to read config file Error: %s", err.Error())
 		return conf, err
 	}
 	conf.fillDefaults()

--- a/net.go
+++ b/net.go
@@ -803,6 +803,9 @@ func (e *EurekaConnection) HeartBeatInstance(ins *Instance) error {
 }
 
 func (i *Instance) Id() string {
+	if i.InstanceId != "" {
+		return i.InstanceId
+	}
 	if i.UniqueID != nil {
 		return i.UniqueID(*i)
 	}

--- a/struct.go
+++ b/struct.go
@@ -77,6 +77,7 @@ type RegisterInstanceJson struct {
 
 // Instance [de]serializeable [to|from] Eureka [XML|JSON].
 type Instance struct {
+	InstanceId       string `xml:"instanceId" json:"instanceId"`
 	HostName         string `xml:"hostName" json:"hostName"`
 	App              string `xml:"app" json:"app"`
 	IPAddr           string `xml:"ipAddr" json:"ipAddr"`


### PR DESCRIPTION
- Support Spring Eureka Server application property instanceId
- Support latest `op-logging`(deprecated log.Criticalf)

Sample eureka app information
```
<application>
  <name>DATASTASH</name>
  <instance>
    <instanceId>192.168.1.5:datastash:9999</instanceId>
    <hostName>192.168.1.5</hostName>
    <app>DATASTASH</app>
    <ipAddr>192.168.1.5</ipAddr>
    <status>UP</status>
    <overriddenstatus>UNKNOWN</overriddenstatus>
    <port enabled="false">9999</port>
    <securePort enabled="false">0</securePort>
    <countryId>0</countryId>
    <dataCenterInfo class="com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo">
      <name>MyOwn</name>
    </dataCenterInfo>
    <leaseInfo>
      <renewalIntervalInSecs>1</renewalIntervalInSecs>
      <durationInSecs>90</durationInSecs>
      <registrationTimestamp>1527566622799</registrationTimestamp>
      <lastRenewalTimestamp>1527575064425</lastRenewalTimestamp>
      <evictionTimestamp>0</evictionTimestamp>
      <serviceUpTimestamp>1527566622290</serviceUpTimestamp>
    </leaseInfo>
    <metadata class="java.util.Collections$EmptyMap"/>
    <homePageUrl>http://192.168.1.5:9999</homePageUrl>
    <statusPageUrl>http://192.168.1.5:9999/info</statusPageUrl>
    <healthCheckUrl>http://192.168.1.5:9999/health</healthCheckUrl>
    <vipAddress>192.168.1.5</vipAddress>
    <secureVipAddress>192.168.1.5</secureVipAddress>
    <isCoordinatingDiscoveryServer>false</isCoordinatingDiscoveryServer>
    <lastUpdatedTimestamp>1527566622799</lastUpdatedTimestamp>
    <lastDirtyTimestamp>1527566622290</lastDirtyTimestamp>
    <actionType>ADDED</actionType>
  </instance>
</application>
```